### PR TITLE
EVEREST-173 add permissions for listing PVs

### DIFF
--- a/pkg/install/operators.go
+++ b/pkg/install/operators.go
@@ -922,6 +922,11 @@ func (o *Operators) serviceAccountClusterRolePolicyRules() []rbacv1.PolicyRule {
 			Resources: []string{"pods"},
 			Verbs:     []string{"list"},
 		},
+		{
+			APIGroups: []string{""},
+			Resources: []string{"persistentvolumes"},
+			Verbs:     []string{"list"},
+		},
 	}
 }
 


### PR DESCRIPTION
EVEREST-173
In order to calculate the available disk size in the cluster we require permissions to list PVs.