### PR TITLE
EVEREST-319 Use KUBECONFIG env var if set

### DIFF
--- a/commands/delete/cluster.go
+++ b/commands/delete/cluster.go
@@ -78,11 +78,11 @@ func initClusterFlags(cmd *cobra.Command) {
 func initClusterViperFlags(cmd *cobra.Command) {
 	viper.BindPFlag("everest.endpoint", cmd.Flags().Lookup("everest.endpoint")) //nolint:errcheck,gosec
 	viper.BindEnv("kubeconfig")
-	viper.BindPFlag("kubeconfig", cmd.Flags().Lookup("kubeconfig"))             //nolint:errcheck,gosec
-	viper.BindPFlag("name", cmd.Flags().Lookup("name"))                         //nolint:errcheck,gosec
-	viper.BindPFlag("assume-yes", cmd.Flags().Lookup("assume-yes"))             //nolint:errcheck,gosec
-	viper.BindPFlag("force", cmd.Flags().Lookup("force"))                       //nolint:errcheck,gosec
-	viper.BindPFlag(                                                            //nolint:errcheck,gosec
+	viper.BindPFlag("kubeconfig", cmd.Flags().Lookup("kubeconfig")) //nolint:errcheck,gosec
+	viper.BindPFlag("name", cmd.Flags().Lookup("name"))             //nolint:errcheck,gosec
+	viper.BindPFlag("assume-yes", cmd.Flags().Lookup("assume-yes")) //nolint:errcheck,gosec
+	viper.BindPFlag("force", cmd.Flags().Lookup("force"))           //nolint:errcheck,gosec
+	viper.BindPFlag(                                                //nolint:errcheck,gosec
 		"ignore-kubernetes-unavailable", cmd.Flags().Lookup("ignore-kubernetes-unavailable"),
 	)
 }

--- a/commands/delete/cluster.go
+++ b/commands/delete/cluster.go
@@ -77,6 +77,7 @@ func initClusterFlags(cmd *cobra.Command) {
 
 func initClusterViperFlags(cmd *cobra.Command) {
 	viper.BindPFlag("everest.endpoint", cmd.Flags().Lookup("everest.endpoint")) //nolint:errcheck,gosec
+	viper.BindEnv("kubeconfig")
 	viper.BindPFlag("kubeconfig", cmd.Flags().Lookup("kubeconfig"))             //nolint:errcheck,gosec
 	viper.BindPFlag("name", cmd.Flags().Lookup("name"))                         //nolint:errcheck,gosec
 	viper.BindPFlag("assume-yes", cmd.Flags().Lookup("assume-yes"))             //nolint:errcheck,gosec

--- a/commands/delete/cluster.go
+++ b/commands/delete/cluster.go
@@ -77,12 +77,12 @@ func initClusterFlags(cmd *cobra.Command) {
 
 func initClusterViperFlags(cmd *cobra.Command) {
 	viper.BindPFlag("everest.endpoint", cmd.Flags().Lookup("everest.endpoint")) //nolint:errcheck,gosec
-	viper.BindEnv("kubeconfig")
-	viper.BindPFlag("kubeconfig", cmd.Flags().Lookup("kubeconfig")) //nolint:errcheck,gosec
-	viper.BindPFlag("name", cmd.Flags().Lookup("name"))             //nolint:errcheck,gosec
-	viper.BindPFlag("assume-yes", cmd.Flags().Lookup("assume-yes")) //nolint:errcheck,gosec
-	viper.BindPFlag("force", cmd.Flags().Lookup("force"))           //nolint:errcheck,gosec
-	viper.BindPFlag(                                                //nolint:errcheck,gosec
+	viper.BindEnv("kubeconfig")                                                 //nolint:errcheck,gosec
+	viper.BindPFlag("kubeconfig", cmd.Flags().Lookup("kubeconfig"))             //nolint:errcheck,gosec
+	viper.BindPFlag("name", cmd.Flags().Lookup("name"))                         //nolint:errcheck,gosec
+	viper.BindPFlag("assume-yes", cmd.Flags().Lookup("assume-yes"))             //nolint:errcheck,gosec
+	viper.BindPFlag("force", cmd.Flags().Lookup("force"))                       //nolint:errcheck,gosec
+	viper.BindPFlag(                                                            //nolint:errcheck,gosec
 		"ignore-kubernetes-unavailable", cmd.Flags().Lookup("ignore-kubernetes-unavailable"),
 	)
 }

--- a/commands/install/operators.go
+++ b/commands/install/operators.go
@@ -114,6 +114,7 @@ func initOperatorsViperFlags(cmd *cobra.Command) {
 	viper.BindPFlag("backup.access-key", cmd.Flags().Lookup("backup.access-key")) //nolint:errcheck,gosec
 	viper.BindPFlag("backup.secret-key", cmd.Flags().Lookup("backup.secret-key")) //nolint:errcheck,gosec
 
+	viper.BindEnv("kubeconfig")
 	viper.BindPFlag("kubeconfig", cmd.Flags().Lookup("kubeconfig")) //nolint:errcheck,gosec
 	viper.BindPFlag("name", cmd.Flags().Lookup("name"))             //nolint:errcheck,gosec
 	viper.BindPFlag("namespace", cmd.Flags().Lookup("namespace"))   //nolint:errcheck,gosec

--- a/commands/install/operators.go
+++ b/commands/install/operators.go
@@ -114,7 +114,7 @@ func initOperatorsViperFlags(cmd *cobra.Command) {
 	viper.BindPFlag("backup.access-key", cmd.Flags().Lookup("backup.access-key")) //nolint:errcheck,gosec
 	viper.BindPFlag("backup.secret-key", cmd.Flags().Lookup("backup.secret-key")) //nolint:errcheck,gosec
 
-	viper.BindEnv("kubeconfig")
+	viper.BindEnv("kubeconfig")                                     //nolint:errcheck,gosec
 	viper.BindPFlag("kubeconfig", cmd.Flags().Lookup("kubeconfig")) //nolint:errcheck,gosec
 	viper.BindPFlag("name", cmd.Flags().Lookup("name"))             //nolint:errcheck,gosec
 	viper.BindPFlag("namespace", cmd.Flags().Lookup("namespace"))   //nolint:errcheck,gosec

--- a/install.sh
+++ b/install.sh
@@ -47,7 +47,7 @@ else
 	echo "KUBECONFIG is not set. Using default k8s cluster"
 fi
 
-echo "Provisioning everest with monitoring disabled"
+echo "Provisioning Everest with monitoring disabled"
 echo "If you want to enable monitoring please refer to the everest installation documentation."
 echo ""
 ./everestctl install operators --backup.enable=false --everest.endpoint=http://127.0.0.1:8080  --monitoring.enable=false --operator.mongodb=true --operator.postgresql=true --operator.xtradb-cluster=true --skip-wizard

--- a/install.sh
+++ b/install.sh
@@ -29,7 +29,6 @@ if [[ ($os == "linux" || $os == "darwin") && $arch == "x86_64" ]]
 then
 	arch="amd64"
 fi
-echo $arch
 
 
 echo "Downloading the latest release of Percona Everest CLI"
@@ -40,10 +39,17 @@ echo "Deploying Backends using docker-compose"
 curl -sL  https://raw.githubusercontent.com/percona/percona-everest-backend/main/quickstart.yml -o quickstart.yml
 docker-compose -f quickstart.yml up -d
 
-echo "Using default k8s cluster to provision everest without backups enabled and monitoring"
-echo "You can run ./everestctl for the wizard setup"
+
+# If KUBECONFIG is set let the user know we are using it
+if [[ -n "${KUBECONFIG}" ]]; then
+	echo "Using KUBECONFIG: ${KUBECONFIG}"
+else
+	echo "KUBECONFIG is not set. Using default k8s cluster"
+fi
+
+echo "Provisioning everest with monitoring disabled"
+echo "If you want to enable monitoring please refer to the everest installation documentation."
 echo ""
-echo "Also you can use --kubeconfig to specify a path for kubeconfig you want to use"
 ./everestctl install operators --backup.enable=false --everest.endpoint=http://127.0.0.1:8080  --monitoring.enable=false --operator.mongodb=true --operator.postgresql=true --operator.xtradb-cluster=true --skip-wizard
 
 if [[ $os == "linux" ]]


### PR DESCRIPTION
EVEREST-319

The order of precedence is the following:
1. --kubeconfig (-k) flag
2. KUBECONFIG env var
3. "~/.kube/config"