### PR TITLE
EVEREST-406 Increased timeout for installing operators

### DIFF
--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -86,7 +86,7 @@ const (
 	APIVersionCoreosV1 = "operators.coreos.com/v1"
 
 	pollInterval = 1 * time.Second
-	pollDuration = 150 * time.Second
+	pollDuration = 300 * time.Second
 )
 
 // ErrEmptyVersionTag Got an empty version tag from GitHub API.


### PR DESCRIPTION
5-minute timeout should be enough to create an install plan on slow Kubernetes clusters or on clusters with high latency. We had this timeout in PMM/DBaaS for a while and all operators were installed successfully. I tested it on clean GKE deployment using Danil's laptop and it ran successfully. 

The original stacktrace shows that it failed because 2.5 minutes were not enough to create an install plan for the Postgres operator and it gets created a couple of moments later 