### PR TITLE
EVEREST-429 Pre-release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Release CLI artifacts
+name: Pre-release CLI artifacts
 on:
   push:
     branches:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,9 +19,6 @@ jobs:
         run: |
           echo "IMAGE_TAG=v${RELEASE_BRANCH_NAME#"release-"}" >> $GITHUB_ENV
 
-      - name: test
-        run: echo "${IMAGE_TAG}"
-
       - name: Build binaries
         run: make release
 
@@ -29,6 +26,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           prerelease: true
+          tag_name: ${{ env.IMAGE_TAG }}
           files: |
             dist/*
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - release-[0-9]+.[0-9]+.[0-9]+*
-      - EVEREST-429-release-ci
 
 jobs:
   build:
@@ -12,22 +11,25 @@ jobs:
       - name: Check out
         uses: actions/checkout@v4
 
-      - name: Set release version
+      - name: Define release branch name
         run: |
-          semantic_version=${github.ref_name#"release-"}
-          echo "IMAGE_TAG=v${semantic_version}" >> $GITHUB_ENV
+          echo "RELEASE_BRANCH_NAME=${GITHUB_REF##*/}" >> $GITHUB_ENV
+
+      - name: Define tag name
+        run: |
+          echo "IMAGE_TAG=v${RELEASE_BRANCH_NAME#"release-"}" >> $GITHUB_ENV
 
       - name: test
         run: echo "${IMAGE_TAG}"
 
-#      - name: Build binaries
-#        run: make release
-#
-#      - name: Create release with binaries
-#        uses: softprops/action-gh-release@v1
-#        with:
-#          prerelease: true
-#          files: |
-#            dist/*
-#        env:
-#          GITHUB_TOKEN: ${{ github.token }}
+      - name: Build binaries
+        run: make release
+
+      - name: Create release with binaries
+        uses: softprops/action-gh-release@v1
+        with:
+          prerelease: true
+          files: |
+            dist/*
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,9 @@
 name: Release CLI artifacts
 on:
   push:
-    tags:
-      - release-*
+    branches:
+      - release-[0-9]+.[0-9]+.[0-9]+*
+      - EVEREST-429-release-ci
 
 jobs:
   build:
@@ -12,16 +13,21 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set release version
-        run: echo "IMAGE_TAG=${{ github.ref_name }}" >> $GITHUB_ENV
+        run: |
+          semantic_version=${github.ref_name#"release-"}
+          echo "IMAGE_TAG=v${semantic_version}" >> $GITHUB_ENV
 
-      - name: Build binaries
-        run: make release
+      - name: test
+        run: echo "${IMAGE_TAG}"
 
-      - name: Create release with binaries
-        uses: softprops/action-gh-release@v1
-        with:
-          prerelease: true
-          files: |
-            dist/*
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
+#      - name: Build binaries
+#        run: make release
+#
+#      - name: Create release with binaries
+#        uses: softprops/action-gh-release@v1
+#        with:
+#          prerelease: true
+#          files: |
+#            dist/*
+#        env:
+#          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Release CLI artifacts
 on:
   push:
     tags:
-      - v*
+      - release-*
 
 jobs:
   build:
@@ -20,7 +20,7 @@ jobs:
       - name: Create release with binaries
         uses: softprops/action-gh-release@v1
         with:
-          draft: true
+          prerelease: true
           files: |
             dist/*
         env:


### PR DESCRIPTION
EVEREST-429

Rebuild artefacts for the _pre-release_ on any new pushes to the `release-X.Y.Z` branch.

The public release and its artefacts will be created from the `release.yaml` workflow of the `percona-everest-backend`. 