### PR TITLE
EVEREST-458 Restart everest operator once a new version of operator i…

### DIFF
--- a/pkg/kubernetes/client/client.go
+++ b/pkg/kubernetes/client/client.go
@@ -339,6 +339,14 @@ func (c *Client) GetDeployment(ctx context.Context, name string, namespace strin
 	return c.clientset.AppsV1().Deployments(namespace).Get(ctx, name, metav1.GetOptions{})
 }
 
+// ListDeployments returns deployment by name.
+func (c *Client) ListDeployments(ctx context.Context, namespace string) (*appsv1.DeploymentList, error) {
+	if namespace == "" {
+		namespace = c.namespace
+	}
+	return c.clientset.AppsV1().Deployments(namespace).List(ctx, metav1.ListOptions{})
+}
+
 // GetSecret returns secret by name.
 func (c *Client) GetSecret(ctx context.Context, name, namespace string) (*corev1.Secret, error) {
 	return c.clientset.CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})

--- a/pkg/kubernetes/client/kubeclient_interface.go
+++ b/pkg/kubernetes/client/kubeclient_interface.go
@@ -40,6 +40,8 @@ type KubeClientConnector interface {
 	GetStorageClasses(ctx context.Context) (*storagev1.StorageClassList, error)
 	// GetDeployment returns deployment by name.
 	GetDeployment(ctx context.Context, name string, namespace string) (*appsv1.Deployment, error)
+	// ListDeployments returns deployment by name.
+	ListDeployments(ctx context.Context, namespace string) (*appsv1.DeploymentList, error)
 	// GetSecret returns secret by name.
 	GetSecret(ctx context.Context, name, namespace string) (*corev1.Secret, error)
 	// ListSecrets returns secrets.

--- a/pkg/kubernetes/client/mock_kube_client_connector.go
+++ b/pkg/kubernetes/client/mock_kube_client_connector.go
@@ -825,6 +825,32 @@ func (_m *MockKubeClientConnector) ListDatabaseClusters(ctx context.Context) (*a
 	return r0, r1
 }
 
+// ListDeployments provides a mock function with given fields: ctx, namespace
+func (_m *MockKubeClientConnector) ListDeployments(ctx context.Context, namespace string) (*appsv1.DeploymentList, error) {
+	ret := _m.Called(ctx, namespace)
+
+	var r0 *appsv1.DeploymentList
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) (*appsv1.DeploymentList, error)); ok {
+		return rf(ctx, namespace)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string) *appsv1.DeploymentList); ok {
+		r0 = rf(ctx, namespace)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*appsv1.DeploymentList)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, namespace)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // ListPods provides a mock function with given fields: ctx, namespace, options
 func (_m *MockKubeClientConnector) ListPods(ctx context.Context, namespace string, options metav1.ListOptions) (*corev1.PodList, error) {
 	ret := _m.Called(ctx, namespace, options)


### PR DESCRIPTION
…s installed

**CHANGE DESCRIPTION**
---
**Problem:**
EVEREST-458

*Short explanation of the problem.*

During the installation of a database engine operator, CLI does not ensure the deployment has been rolled out. Hence for MongoDB installation, since it's too long and the rollout is slower than others the everest operator gets restarted and after the restart, a psmdb operator is completely deployed. 

Also, during the QA process and after a discussion we decided to restart the everest operator only if a new version of an operator was deployed 

**Solution:**

Wait for the deployment rollout during the installation of an operator and restart the everest operator once it a new version of a database engine operator is deployed. 

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
