### PR TITLE
EVEREST-488 Fixed catalog versioning

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -47,8 +47,8 @@ var (
 // for the release it returns everest-catalog:X.Y.Z.
 func CatalogImage() string {
 	catalogImage = devCatalogImage
-	_, err := goversion.NewSemver(Version)
-	if !strings.Contains(Version, "dirty") && Version != "" && err == nil {
+	v, err := goversion.NewSemver(Version)
+	if Version != "" && err == nil && v.Prerelease() == "" {
 		catalogImage = fmt.Sprintf(releaseCatalogImage, Version)
 	}
 	return catalogImage

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -15,4 +15,6 @@ func TestCatalogImage(t *testing.T) {
 	assert.Equal(t, CatalogImage(), devCatalogImage)
 	Version = "c09550"
 	assert.Equal(t, CatalogImage(), devCatalogImage)
+	Version = "0.3.0-37-gf1f07f6"
+	assert.Equal(t, CatalogImage(), devCatalogImage)
 }


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
EVEREST-488

*Short explanation of the problem.*

the CLI sets image something like this
```
    image: docker.io/percona/everest-catalog:0.3.0-37-gf1f07f6
```


**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?
