### PR TITLE
EVEREST-458 Increase timeout for restarting pod

### DIFF
--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -864,7 +864,7 @@ func (k *Kubernetes) updateClusterRoleBindingNamespace(o map[string]interface{},
 // RestartEverestOperator restarts everest pod.
 func (k *Kubernetes) RestartEverestOperator(ctx context.Context, namespace string) error {
 	var pod corev1.Pod
-	err := wait.PollUntilContextTimeout(ctx, 5*time.Second, time.Minute, true, func(ctx context.Context) (bool, error) {
+	err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
 		p, err := k.getEverestOperatorPod(ctx, namespace)
 		if err != nil {
 			if errors.Is(err, errNoEverestOperatorPods) {
@@ -884,7 +884,7 @@ func (k *Kubernetes) RestartEverestOperator(ctx context.Context, namespace strin
 		return err
 	}
 
-	return wait.PollUntilContextTimeout(ctx, 5*time.Second, time.Minute, true, func(ctx context.Context) (bool, error) {
+	return wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
 		pod, err := k.getEverestOperatorPod(ctx, namespace)
 		if err != nil {
 			return false, err


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
EVEREST-458

*Short explanation of the problem.*
One minute is not enough to wait for the pod to be running 

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*
Increased timeout to 5 minutes

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
