### PR TITLE
EVEREST-107 Fix tests run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -303,18 +303,8 @@ jobs:
           'test-pg-operator',
           'test-pxc-operator'
         ]
-    steps:
-      - name: Wait for EVEREST BE to be available
-        timeout-minutes: 15
-        run: |
-          while ! curl -sSf http://127.0.0.1:8080 > /dev/null; do
-            echo "Waiting for EVEREST BE..."
-            sleep 15
-          done
-          echo "EVEREST BE is available."
-
-      - name: CLI tests
-        uses: ./.github/workflows/cli-tests.yml
-        secrets: inherit
-        with:
-          make_target: ${{ matrix.make_target }}
+    name: CLI tests
+    uses: ./.github/workflows/cli-tests.yml
+    secrets: inherit
+    with:
+      make_target: ${{ matrix.make_target }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,11 +238,22 @@ jobs:
           ref: 'main'
           path: percona-everest-backend
 
+      - name: Set up Go release for Everest BE
+        uses: percona-platform/setup-go@v4
+        with:
+          go-version-file: './percona-everest-backend/go.mod'
+
       - name: Run Everest backend
         working-directory: percona-everest-backend
         run: |
           make local-env-up
           SECRETS_ROOT_KEY=$(openssl rand -base64 32) make run-debug &
+
+
+      - name: Set up Go release for CLI
+        uses: percona-platform/setup-go@v4
+        with:
+          go-version-file: './go.mod'
 
       - name: Build CLI binary
         run: |
@@ -258,7 +269,7 @@ jobs:
         run: git config --global url."https://percona-platform-robot:${ROBOT_TOKEN}@github.com".insteadOf "https://github.com"
 
       - name: Wait for EVEREST BE to be available
-        timeout-minutes: 10
+        timeout-minutes: 15
         run: |
           while ! curl -sSf http://127.0.0.1:8080 > /dev/null; do
             echo "Waiting for EVEREST BE..."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,6 +257,16 @@ jobs:
           ROBOT_TOKEN: ${{ secrets.ROBOT_TOKEN }}
         run: git config --global url."https://percona-platform-robot:${ROBOT_TOKEN}@github.com".insteadOf "https://github.com"
 
+      - name: Wait for EVEREST BE to be available
+        timeout-minutes: 10
+        run: |
+          while ! curl -sSf http://127.0.0.1:8080 > /dev/null; do
+            echo "Waiting for EVEREST BE..."
+            sleep 15
+          done
+          echo "EVEREST BE is available."
+
+
       - name: Run integration tests
         working-directory: cli-tests
         id: cli-tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -303,8 +303,18 @@ jobs:
           'test-pg-operator',
           'test-pxc-operator'
         ]
-    name: CLI tests
-    uses: ./.github/workflows/cli-tests.yml
-    secrets: inherit
-    with:
-      make_target: ${{ matrix.make_target }}
+    steps:
+      - name: Wait for EVEREST BE to be available
+        timeout-minutes: 15
+        run: |
+          while ! curl -sSf http://127.0.0.1:8080 > /dev/null; do
+            echo "Waiting for EVEREST BE..."
+            sleep 15
+          done
+          echo "EVEREST BE is available."
+
+      - name: CLI tests
+        uses: ./.github/workflows/cli-tests.yml
+        secrets: inherit
+        with:
+          make_target: ${{ matrix.make_target }}

--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -66,11 +66,16 @@ jobs:
           ref: 'main'
           path: percona-everest-backend
 
+      - name: Set up Go release for Everest BE
+        uses: percona-platform/setup-go@v4
+        with:
+          go-version-file: './percona-everest-backend/go.mod'
+
       - name: Run Everest backend
         working-directory: percona-everest-backend
         run: |
           make local-env-up
-          make run-debug &
+          SECRETS_ROOT_KEY=$(openssl rand -base64 32) make run-debug &
 
       # https://help.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners#supported-runners-and-hardware-resources
       # https://minikube.sigs.k8s.io/docs/drivers/docker/
@@ -82,6 +87,11 @@ jobs:
           minikube config set cpus 2
           minikube start
 
+      - name: Set up Go release for CLI
+        uses: percona-platform/setup-go@v4
+        with:
+          go-version-file: './go.mod'
+
       - name: Build CLI binary
         run: |
           make init
@@ -91,6 +101,15 @@ jobs:
         env:
           ROBOT_TOKEN: ${{ secrets.ROBOT_TOKEN }}
         run: git config --global url."https://percona-platform-robot:${ROBOT_TOKEN}@github.com".insteadOf "https://github.com"
+
+      - name: Wait for EVEREST BE to be available
+        timeout-minutes: 15
+        run: |
+          while ! curl -sSf http://127.0.0.1:8080 > /dev/null; do
+            echo "Waiting for EVEREST BE..."
+            sleep 15
+          done
+          echo "EVEREST BE is available."
 
       - name: Run ${{ env.MAKE_TARGET }} integration tests
         working-directory: cli-tests


### PR DESCRIPTION
**Fix integration tests failure**
---
**Problem:**
EVEREST-107

The integration tests were [failing](https://github.com/percona/percona-everest-cli/actions/runs/6589667490/job/17904624216) with
```
2023-10-20T15:27:22Z	error	install/operators.go:207	Could not connect to Everest. Make sure Everest is running and is accessible from this machine.	{"component": "install/operators"}
```

Long story short - BE runs in background too slow and tests are running before it gets available

-------------------
Investigation:
1. Tried to move the BE run to the foreground to check if it gets available it all - [it does](https://github.com/percona/percona-everest-cli/actions/runs/6599336542/job/17928247232).
2. Noticed it takes long to run the BE (perhaps because of the vault has been added)
3. Added the waiting step, so the CI would check if the BE is actually available before running the tests. [It worked](https://github.com/percona/percona-everest-cli/actions/runs/6599480752/job/17928532172). 

