### PR TITLE
EVEREST-579: don't restart everest operator

### DIFF
--- a/pkg/install/operators.go
+++ b/pkg/install/operators.go
@@ -746,7 +746,7 @@ func (o *Operators) provisionOperators(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	if len(deploymentsBefore) != len(deploymentsAfter) {
+	if len(deploymentsBefore) != 0 && len(deploymentsBefore) != len(deploymentsAfter) {
 		return o.restartEverestOperatorPod(ctx)
 	}
 	return nil


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
EVEREST-579

**Cause:**
- Everest operator was restart during every provisioning
- It's not required on the first deploy

**Solution:**
- No restart on first deploy
- This does not fix the root cause but shall prevent the issue from occurring during the initial provisioning

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
