### PR TITLE
EVEREST-107: use cookie instead of auth header

### DIFF
--- a/pkg/everest/client/client.go
+++ b/pkg/everest/client/client.go
@@ -75,7 +75,13 @@ func NewProxiedEverest(config *rest.Config, namespace, everestPwd string) (*Ever
 			url.PathEscape(namespace),
 		),
 		client.WithRequestEditorFn(func(ctx context.Context, req *http.Request) error {
-			req.Header.Add("Authentication", fmt.Sprintf("Bearer %s", everestPwd))
+			// We can't use the Authorization header because it's automatically
+			// removed by the k8s proxy.
+			// See https://github.com/kubernetes/kubernetes/issues/38775 for details.
+			req.AddCookie(&http.Cookie{
+				Name:  "everest_token",
+				Value: everestPwd,
+			})
 			return nil
 		}),
 	)

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -686,6 +686,8 @@ func (k *Kubernetes) InstallOperator(ctx context.Context, req InstallOperatorReq
 		deploymentName = "vm-operator-vm-operator"
 	}
 
+	k.l.Debugf("Waiting for deployment rollout %s/%s", req.Namespace, deploymentName)
+
 	return k.client.DoRolloutWait(ctx, types.NamespacedName{Namespace: req.Namespace, Name: deploymentName})
 }
 
@@ -694,6 +696,8 @@ func (k *Kubernetes) approveInstallPlan(ctx context.Context, namespace, installP
 	if err != nil {
 		return false, err
 	}
+
+	k.l.Debugf("Approving install plan %s/%s", namespace, installPlanName)
 
 	ip.Spec.Approved = true
 	_, err = k.client.UpdateInstallPlan(ctx, namespace, ip)


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
EVEREST-107

*Short explanation of the problem.*
We can't use the Authorization header because it's automatically removed by the k8s proxy.

**Cause:**
Authorization header is removed by k8s.

**Solution:**
Use cookie

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
