### PR TITLE
EVEREST-778: fix everest URL construction

### DIFF
--- a/pkg/everest/client/client.go
+++ b/pkg/everest/client/client.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 
 	"github.com/percona/percona-everest-backend/client"
 )
@@ -43,9 +44,13 @@ func NewEverest(everestClient *client.Client) *Everest {
 }
 
 // NewEverestFromURL returns a new Everest from a provided URL.
-func NewEverestFromURL(url, everestPwd string) (*Everest, error) {
+func NewEverestFromURL(rawURL, everestPwd string) (*Everest, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, errors.Join(err, errors.New("could not parse Everest URL"))
+	}
 	everestCl, err := client.NewClient(
-		fmt.Sprintf("%s/v1", url),
+		u.JoinPath("v1").String(),
 		client.WithRequestEditorFn(func(ctx context.Context, req *http.Request) error {
 			req.Header.Set("Cookie", fmt.Sprintf("everest_token=%s", everestPwd))
 			return nil


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
EVEREST-778

When Everest URL ends with a slash, some non-GET endpoints return an error.

**Cause:**
The Everest URL is not constructed properly and has a double slash.

**Solution:**
Construct Everest URL 
**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
