### PR TITLE
EVEREST-633 Rename restricted namespaces

### DIFF
--- a/cli-tests/tests/flow/mongodb-operator.spec.ts
+++ b/cli-tests/tests/flow/mongodb-operator.spec.ts
@@ -27,13 +27,13 @@ test.describe('Everest CLI install', async () => {
   test('install only mongodb-operator', async ({ page, cli, request }) => {
     const verifyClusterResources = async () => {
       await test.step('verify installed operators in k8s', async () => {
-        const perconaEverestPodsOut = await cli.exec('kubectl get pods --namespace=percona-everest');
+        const perconaEverestPodsOut = await cli.exec('kubectl get pods --namespace=everest-system');
 
         await perconaEverestPodsOut.outContainsNormalizedMany([
           'everest-operator-controller-manager',
         ]);
 
-        const out = await cli.exec('kubectl get pods --namespace=percona-everest-operators');
+        const out = await cli.exec('kubectl get pods --namespace=everest-operators');
 
         await out.outContainsNormalizedMany([
           'percona-server-mongodb-operator',
@@ -49,7 +49,7 @@ test.describe('Everest CLI install', async () => {
 
     await test.step('run everest install command', async () => {
       const out = await cli.everestExecSkipWizard(
-        `install --operator.mongodb=true --operator.postgresql=false --operator.xtradb-cluster=false --namespace=percona-everest-operators`,
+        `install --operator.mongodb=true --operator.postgresql=false --operator.xtradb-cluster=false --namespace=everest-operators`,
       );
 
       await out.assertSuccess();

--- a/cli-tests/tests/flow/pg-operator.spec.ts
+++ b/cli-tests/tests/flow/pg-operator.spec.ts
@@ -27,13 +27,13 @@ test.describe('Everest CLI install', async () => {
   test('install only postgresql-operator', async ({ page, cli, request }) => {
     const verifyClusterResources = async () => {
       await test.step('verify installed operators in k8s', async () => {
-        const perconaEverestPodsOut = await cli.exec('kubectl get pods --namespace=percona-everest');
+        const perconaEverestPodsOut = await cli.exec('kubectl get pods --namespace=everest-system');
 
         await perconaEverestPodsOut.outContainsNormalizedMany([
           'everest-operator-controller-manager',
         ]);
 
-        const out = await cli.exec('kubectl get pods --namespace=percona-everest-operators');
+        const out = await cli.exec('kubectl get pods --namespace=everest-operators');
 
         await out.outContainsNormalizedMany([
           'percona-postgresql-operator',
@@ -48,7 +48,7 @@ test.describe('Everest CLI install', async () => {
 
     await test.step('run everest install command', async () => {
       const out = await cli.everestExecSkipWizard(
-        `install --operator.mongodb=false --operator.postgresql=true --operator.xtradb-cluster=false --namespace=percona-everest-operators`,
+        `install --operator.mongodb=false --operator.postgresql=true --operator.xtradb-cluster=false --namespace=everest-operators`,
       );
 
       await out.assertSuccess();
@@ -64,13 +64,13 @@ test.describe('Everest CLI install', async () => {
 
     await test.step('re-run everest install command', async () => {
       await page.waitForTimeout(60_000);
-      const operator = await cli.exec(`kubectl -n percona-everest get po | grep everest|awk {'print $1'}`);
+      const operator = await cli.exec(`kubectl -n everest-system get po | grep everest|awk {'print $1'}`);
       await operator.assertSuccess();
 
       const out = await cli.everestExecSkipWizard(
-        `install --operator.mongodb=false --operator.postgresql=true --operator.xtradb-cluster=true --namespace=percona-everest-operators`,
+        `install --operator.mongodb=false --operator.postgresql=true --operator.xtradb-cluster=true --namespace=everest-operators`,
       );
-      const restartedOperator = await cli.exec(`kubectl -n percona-everest get po | grep everest|awk {'print $1'}`);
+      const restartedOperator = await cli.exec(`kubectl -n everest-system get po | grep everest|awk {'print $1'}`);
       await restartedOperator.assertSuccess();
 
       expect(operator.getStdOutLines()[0]).not.toEqual(restartedOperator.getStdOutLines()[0]);

--- a/cli-tests/tests/flow/pxc-operator.spec.ts
+++ b/cli-tests/tests/flow/pxc-operator.spec.ts
@@ -27,13 +27,13 @@ test.describe('Everest CLI install', async () => {
   test('install only xtradb-cluster-operator', async ({ page, cli, request }) => {
     const verifyClusterResources = async () => {
       await test.step('verify installed operators in k8s', async () => {
-        const perconaEverestPodsOut = await cli.exec('kubectl get pods --namespace=percona-everest');
+        const perconaEverestPodsOut = await cli.exec('kubectl get pods --namespace=everest-system');
 
         await perconaEverestPodsOut.outContainsNormalizedMany([
           'everest-operator-controller-manager',
         ]);
 
-        const out = await cli.exec('kubectl get pods --namespace=percona-everest-operators');
+        const out = await cli.exec('kubectl get pods --namespace=everest-operators');
 
         await out.outContainsNormalizedMany([
           'percona-xtradb-cluster-operator',
@@ -49,7 +49,7 @@ test.describe('Everest CLI install', async () => {
 
     await test.step('run everest install command', async () => {
       const out = await cli.everestExecSkipWizard(
-        `install --operator.mongodb=false --operator.postgresql=false --operator.xtradb-cluster=true --namespace=percona-everest-operators`,
+        `install --operator.mongodb=false --operator.postgresql=false --operator.xtradb-cluster=true --namespace=everest-operators`,
       );
 
       await out.assertSuccess();

--- a/install.sh
+++ b/install.sh
@@ -35,8 +35,8 @@ fi
 echo "Provisioning Everest with monitoring disabled"
 echo "If you want to enable monitoring please refer to the everest installation documentation."
 echo ""
-./everestctl install --operator.mongodb=true --operator.postgresql=true --operator.xtradb-cluster=true --skip-wizard
+./everestctl install --namespace everest --operator.mongodb=true --operator.postgresql=true --operator.xtradb-cluster=true --skip-wizard
 
 echo "Your provisioned Everest instance will be available at http://127.0.0.1:8080"
 echo "Exposing Everest using kubectl port-forwarding. You can expose it manually"
-kubectl port-forward -n percona-everest deployment/percona-everest 8080:8080
+kubectl port-forward -n everest-system deployment/percona-everest 8080:8080

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -77,9 +77,9 @@ const (
 	dbsOperatorGroup = "everest-databases"
 
 	// SystemNamespace is the namespace where everest is installed.
-	SystemNamespace = "percona-everest"
+	SystemNamespace = "everest-system"
 	// monitoringNamespace is the namespace where the monitoring stack is installed.
-	monitoringNamespace = "percona-everest-monitoring"
+	monitoringNamespace = "everest-monitoring"
 	// EverestMonitoringNamespaceEnvVar is the name of the environment variable that holds the monitoring namespace.
 	EverestMonitoringNamespaceEnvVar = "MONITORING_NAMESPACE"
 )


### PR DESCRIPTION
**Rename restricted namespaces**
---
**Problem:**
EVEREST-633

`everest-system` and `everest-monitoring` are more descriptive names that `percona-everest` and `percona-everest-monitoring`.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?

**Tests**
- [x] Is an Integration test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?
