### PR TITLE
EVEREST-838 Fix uninstall command

### DIFF
--- a/data/crds/olm/everest-catalog.yaml
+++ b/data/crds/olm/everest-catalog.yaml
@@ -2,7 +2,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
 metadata:
   name: everest-catalog
-  namespace: olm
+  namespace: everest-olm
 spec:
   displayName: Everest Catalog
   publisher: Percona

--- a/data/crds/olm/olm.yaml
+++ b/data/crds/olm/olm.yaml
@@ -11,18 +11,6 @@ metadata:
     pod-security.kubernetes.io/warn: restricted
     pod-security.kubernetes.io/warn-version: latest
 ---
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: operators
-  labels:
-    pod-security.kubernetes.io/enforce: baseline
-    pod-security.kubernetes.io/enforce-version: latest
-    pod-security.kubernetes.io/audit: restricted
-    pod-security.kubernetes.io/audit-version: latest
-    pod-security.kubernetes.io/warn: restricted
-    pod-security.kubernetes.io/warn-version: latest
----
 kind: ServiceAccount
 apiVersion: v1
 metadata:
@@ -217,12 +205,6 @@ rules:
 - apiGroups: ["packages.operators.coreos.com"]
   resources: ["packagemanifests", "packagemanifests/icon"]
   verbs: ["get", "list", "watch"]
----
-apiVersion: operators.coreos.com/v1
-kind: OperatorGroup
-metadata:
-  name: global-operators
-  namespace: operators
 ---
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup

--- a/data/crds/olm/olm.yaml
+++ b/data/crds/olm/olm.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: olm
+  name: everest-olm
   labels:
     pod-security.kubernetes.io/enforce: restricted
     pod-security.kubernetes.io/enforce-version: latest
@@ -15,7 +15,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: olm-operator-serviceaccount
-  namespace: olm
+  namespace: everest-olm
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -39,7 +39,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: olm-operator-serviceaccount
-  namespace: olm
+  namespace: everest-olm
 ---
 apiVersion: operators.coreos.com/v1
 kind: OLMConfig
@@ -50,7 +50,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: olm-operator
-  namespace: olm
+  namespace: everest-olm
   labels:
     app: olm-operator
 spec:
@@ -117,7 +117,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: catalog-operator
-  namespace: olm
+  namespace: everest-olm
   labels:
     app: catalog-operator
 spec:
@@ -147,7 +147,7 @@ spec:
           - /bin/catalog
           args:
           - '--namespace'
-          - olm
+          - everest-olm
           - --configmapServerImage=quay.io/operator-framework/configmap-operator-registry:latest
           - --util-image
           -  quay.io/operator-framework/olm@sha256:163bacd69001fea0c666ecf8681e9485351210cde774ee345c06f80d5a651473
@@ -210,16 +210,16 @@ apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
   name: olm-operators
-  namespace: olm
+  namespace: everest-olm
 spec:
   targetNamespaces:
-    - olm
+    - everest-olm
 ---
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   name: packageserver
-  namespace: olm
+  namespace: everest-olm
   labels:
     olm.version: v0.25.0
 spec:
@@ -316,7 +316,7 @@ spec:
                 - --secure-port
                 - "5443"
                 - --global-namespace
-                - olm
+                - everest-olm
                 image: quay.io/operator-framework/olm@sha256:163bacd69001fea0c666ecf8681e9485351210cde774ee345c06f80d5a651473
                 imagePullPolicy: Always
                 ports:

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/go-version v1.6.0
 	github.com/operator-framework/api v0.22.0
 	github.com/operator-framework/operator-lifecycle-manager v0.26.0
-	github.com/percona/everest-operator v0.6.0-dev1.0.20240207193854-cdd70b8eb1e6
+	github.com/percona/everest-operator v0.6.0-dev1.0.20240214112044-8f2dea595284
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.8.4

--- a/go.sum
+++ b/go.sum
@@ -525,8 +525,8 @@ github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/9
 github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAvS1LBMMhTE=
 github.com/pelletier/go-toml/v2 v2.1.0 h1:FnwAJ4oYMvbT/34k9zzHuZNrhlz48GB3/s6at6/MHO4=
 github.com/pelletier/go-toml/v2 v2.1.0/go.mod h1:tJU2Z3ZkXwnxa4DPO899bsyIoywizdUvyaeZurnPPDc=
-github.com/percona/everest-operator v0.6.0-dev1.0.20240207193854-cdd70b8eb1e6 h1:leGa/XuWVstdYyj61r92xByjuT52jsbVroHB0fj4j7A=
-github.com/percona/everest-operator v0.6.0-dev1.0.20240207193854-cdd70b8eb1e6/go.mod h1:45pGpvWrPy495qiQqxNuOJor4wif+vTTTJP4Qee8qZk=
+github.com/percona/everest-operator v0.6.0-dev1.0.20240214112044-8f2dea595284 h1:5LKWEvGtaimDPVI3Rj9tFxO+g/zAjUJq0yFIzznQGfc=
+github.com/percona/everest-operator v0.6.0-dev1.0.20240214112044-8f2dea595284/go.mod h1:45pGpvWrPy495qiQqxNuOJor4wif+vTTTJP4Qee8qZk=
 github.com/percona/percona-backup-mongodb v1.8.1-0.20230920143330-3b1c2e263901 h1:BDgsZRCjEuxl2/z4yWBqB0s8d20shuIDks7/RVdZiLs=
 github.com/percona/percona-backup-mongodb v1.8.1-0.20230920143330-3b1c2e263901/go.mod h1:fZRCMpUqkWlLVdRKqqaj001LoVP2eo6F0ZhoMPeXDng=
 github.com/percona/percona-postgresql-operator v0.0.0-20231220140959-ad5eef722609 h1:+UOK4gcHrRgqjo4smgfwT7/0apF6PhAJdQIdAV4ub/M=

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -65,8 +65,6 @@ const (
 	pgOperatorChannel      = "stable-v2"
 	vmOperatorChannel      = "stable-v0"
 
-	// catalogSourceNamespace is the namespace where the catalog source is installed.
-	catalogSourceNamespace = "everest-olm"
 	// catalogSource is the name of the catalog source.
 	catalogSource = "everest-catalog"
 
@@ -202,7 +200,7 @@ func (o *Install) installVMOperator(ctx context.Context) error {
 		Name:                   vmOperatorName,
 		OperatorGroup:          monitoringOperatorGroup,
 		CatalogSource:          catalogSource,
-		CatalogSourceNamespace: catalogSourceNamespace,
+		CatalogSourceNamespace: kubernetes.OLMNamespace,
 		Channel:                vmOperatorChannel,
 		InstallPlanApproval:    v1alpha1.ApprovalManual,
 	}
@@ -484,7 +482,7 @@ func (o *Install) installOperator(ctx context.Context, channel, operatorName, na
 			Name:                   operatorName,
 			OperatorGroup:          systemOperatorGroup,
 			CatalogSource:          catalogSource,
-			CatalogSourceNamespace: catalogSourceNamespace,
+			CatalogSourceNamespace: kubernetes.OLMNamespace,
 			Channel:                channel,
 			InstallPlanApproval:    v1alpha1.ApprovalManual,
 			SubscriptionConfig: &v1alpha1.SubscriptionConfig{

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -66,7 +66,7 @@ const (
 	vmOperatorChannel      = "stable-v0"
 
 	// catalogSourceNamespace is the namespace where the catalog source is installed.
-	catalogSourceNamespace = "olm"
+	catalogSourceNamespace = "everest-olm"
 	// catalogSource is the name of the catalog source.
 	catalogSource = "everest-catalog"
 

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -79,8 +79,8 @@ const (
 
 	// SystemNamespace is the namespace where everest is installed.
 	SystemNamespace = "everest-system"
-	// monitoringNamespace is the namespace where the monitoring stack is installed.
-	monitoringNamespace = "everest-monitoring"
+	// MonitoringNamespace is the namespace where the monitoring stack is installed.
+	MonitoringNamespace = "everest-monitoring"
 	// EverestMonitoringNamespaceEnvVar is the name of the environment variable that holds the monitoring namespace.
 	EverestMonitoringNamespaceEnvVar = "MONITORING_NAMESPACE"
 	// disableTelemetryEnvVar is the name of the environment variable that disables telemetry.
@@ -182,7 +182,7 @@ func (o *Install) populateConfig() error {
 		return errors.New("namespace list is empty. Specify at least one namespace using the --namespace flag")
 	}
 	for _, ns := range o.config.Namespaces {
-		if ns == SystemNamespace || ns == monitoringNamespace {
+		if ns == SystemNamespace || ns == MonitoringNamespace {
 			return fmt.Errorf("'%s' namespace is reserved for Everest internals. Please specify another namespace", ns)
 		}
 	}
@@ -192,13 +192,13 @@ func (o *Install) populateConfig() error {
 
 func (o *Install) installVMOperator(ctx context.Context) error {
 	o.l.Info("Creating operator group for everest")
-	if err := o.kubeClient.CreateOperatorGroup(ctx, monitoringOperatorGroup, monitoringNamespace, []string{}); err != nil {
+	if err := o.kubeClient.CreateOperatorGroup(ctx, monitoringOperatorGroup, MonitoringNamespace, []string{}); err != nil {
 		return err
 	}
 	o.l.Infof("Installing %s operator", vmOperatorName)
 
 	params := kubernetes.InstallOperatorRequest{
-		Namespace:              monitoringNamespace,
+		Namespace:              MonitoringNamespace,
 		Name:                   vmOperatorName,
 		OperatorGroup:          monitoringOperatorGroup,
 		CatalogSource:          catalogSource,
@@ -217,7 +217,7 @@ func (o *Install) installVMOperator(ctx context.Context) error {
 
 func (o *Install) provisionMonitoringStack(ctx context.Context) error {
 	l := o.l.With("action", "monitoring")
-	if err := o.createNamespace(monitoringNamespace); err != nil {
+	if err := o.createNamespace(MonitoringNamespace); err != nil {
 		return err
 	}
 
@@ -225,7 +225,7 @@ func (o *Install) provisionMonitoringStack(ctx context.Context) error {
 	if err := o.installVMOperator(ctx); err != nil {
 		return err
 	}
-	if err := o.kubeClient.ProvisionMonitoring(monitoringNamespace); err != nil {
+	if err := o.kubeClient.ProvisionMonitoring(MonitoringNamespace); err != nil {
 		return errors.Join(err, errors.New("could not provision monitoring configuration"))
 	}
 
@@ -501,7 +501,7 @@ func (o *Install) installOperator(ctx context.Context, channel, operatorName, na
 			params.SubscriptionConfig.Env = append(params.SubscriptionConfig.Env, []corev1.EnvVar{
 				{
 					Name:  EverestMonitoringNamespaceEnvVar,
-					Value: monitoringNamespace,
+					Value: MonitoringNamespace,
 				},
 				{
 					Name:  kubernetes.EverestDBNamespacesEnvVar,

--- a/pkg/kubernetes/backup_storage.go
+++ b/pkg/kubernetes/backup_storage.go
@@ -1,0 +1,102 @@
+// everest
+// Copyright (C) 2023 Percona LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package kubernetes ...
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+
+	everestv1alpha1 "github.com/percona/everest-operator/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	backupStorageNameLabelTmpl = "backupStorage-%s"
+	backupStorageLabelValue    = "used"
+)
+
+// ListBackupStorages returns list of managed backup storages.
+func (k *Kubernetes) ListBackupStorages(ctx context.Context) (*everestv1alpha1.BackupStorageList, error) {
+	return k.client.ListBackupStorages(ctx, metav1.ListOptions{})
+}
+
+// GetBackupStorage returns backup storages by provided name.
+func (k *Kubernetes) GetBackupStorage(ctx context.Context, name string) (*everestv1alpha1.BackupStorage, error) {
+	return k.client.GetBackupStorage(ctx, name)
+}
+
+// CreateBackupStorage returns backup storages by provided name.
+func (k *Kubernetes) CreateBackupStorage(ctx context.Context, storage *everestv1alpha1.BackupStorage) error {
+	return k.client.CreateBackupStorage(ctx, storage)
+}
+
+// UpdateBackupStorage returns backup storages by provided name.
+func (k *Kubernetes) UpdateBackupStorage(ctx context.Context, storage *everestv1alpha1.BackupStorage) error {
+	return k.client.UpdateBackupStorage(ctx, storage)
+}
+
+// DeleteBackupStorage returns backup storages by provided name.
+func (k *Kubernetes) DeleteBackupStorage(ctx context.Context, name string) error {
+	return k.client.DeleteBackupStorage(ctx, name)
+}
+
+// IsBackupStorageUsed checks that a backup storage by provided name is used across k8s cluster.
+func (k *Kubernetes) IsBackupStorageUsed(ctx context.Context, backupStorageName string) (bool, error) {
+	_, err := k.client.GetBackupStorage(ctx, backupStorageName)
+	if err != nil {
+		return false, err
+	}
+
+	namespaces, err := k.GetDBNamespaces(ctx, k.Namespace())
+	if err != nil {
+		return false, err
+	}
+
+	options := metav1.ListOptions{
+		LabelSelector: metav1.FormatLabelSelector(&metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				fmt.Sprintf(backupStorageNameLabelTmpl, backupStorageName): backupStorageLabelValue,
+			},
+		}),
+	}
+
+	for _, namespace := range namespaces {
+		list, err := k.client.ListDatabaseClusters(ctx, namespace, options)
+		if err != nil {
+			return false, err
+		}
+		if len(list.Items) > 0 {
+			return true, nil
+		}
+		bList, err := k.client.ListDatabaseClusterBackups(ctx, namespace, options)
+		if err != nil {
+			return false, err
+		}
+		if len(bList.Items) > 0 {
+			return true, nil
+		}
+		rList, err := k.client.ListDatabaseClusterRestores(ctx, namespace, options)
+		if err != nil {
+			return false, err
+		}
+		if len(rList.Items) > 0 {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}

--- a/pkg/kubernetes/backup_storage.go
+++ b/pkg/kubernetes/backup_storage.go
@@ -30,13 +30,13 @@ const (
 )
 
 // ListBackupStorages returns list of managed backup storages.
-func (k *Kubernetes) ListBackupStorages(ctx context.Context) (*everestv1alpha1.BackupStorageList, error) {
-	return k.client.ListBackupStorages(ctx, metav1.ListOptions{})
+func (k *Kubernetes) ListBackupStorages(ctx context.Context, namespace string) (*everestv1alpha1.BackupStorageList, error) {
+	return k.client.ListBackupStorages(ctx, namespace, metav1.ListOptions{})
 }
 
 // GetBackupStorage returns backup storages by provided name.
-func (k *Kubernetes) GetBackupStorage(ctx context.Context, name string) (*everestv1alpha1.BackupStorage, error) {
-	return k.client.GetBackupStorage(ctx, name)
+func (k *Kubernetes) GetBackupStorage(ctx context.Context, namespace, name string) (*everestv1alpha1.BackupStorage, error) {
+	return k.client.GetBackupStorage(ctx, namespace, name)
 }
 
 // CreateBackupStorage returns backup storages by provided name.
@@ -50,18 +50,18 @@ func (k *Kubernetes) UpdateBackupStorage(ctx context.Context, storage *everestv1
 }
 
 // DeleteBackupStorage returns backup storages by provided name.
-func (k *Kubernetes) DeleteBackupStorage(ctx context.Context, name string) error {
-	return k.client.DeleteBackupStorage(ctx, name)
+func (k *Kubernetes) DeleteBackupStorage(ctx context.Context, namespace, name string) error {
+	return k.client.DeleteBackupStorage(ctx, namespace, name)
 }
 
 // IsBackupStorageUsed checks that a backup storage by provided name is used across k8s cluster.
-func (k *Kubernetes) IsBackupStorageUsed(ctx context.Context, backupStorageName string) (bool, error) {
-	_, err := k.client.GetBackupStorage(ctx, backupStorageName)
+func (k *Kubernetes) IsBackupStorageUsed(ctx context.Context, namespace, backupStorageName string) (bool, error) {
+	_, err := k.client.GetBackupStorage(ctx, namespace, backupStorageName)
 	if err != nil {
 		return false, err
 	}
 
-	namespaces, err := k.GetDBNamespaces(ctx, k.Namespace())
+	namespaces, err := k.GetDBNamespaces(ctx, namespace)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/kubernetes/client/backup_storage.go
+++ b/pkg/kubernetes/client/backup_storage.go
@@ -1,0 +1,51 @@
+// everest
+// Copyright (C) 2023 Percona LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package client ...
+package client
+
+import (
+	"context"
+
+	everestv1alpha1 "github.com/percona/everest-operator/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// CreateBackupStorage creates an backupStorage.
+func (c *Client) CreateBackupStorage(ctx context.Context, storage *everestv1alpha1.BackupStorage) error {
+	_, err := c.customClientSet.BackupStorage(storage.Namespace).Create(ctx, storage, metav1.CreateOptions{})
+	return err
+}
+
+// UpdateBackupStorage updates an backupStorage.
+func (c *Client) UpdateBackupStorage(ctx context.Context, storage *everestv1alpha1.BackupStorage) error {
+	_, err := c.customClientSet.BackupStorage(storage.Namespace).Update(ctx, storage, metav1.UpdateOptions{})
+	return err
+}
+
+// GetBackupStorage returns the backupStorage.
+func (c *Client) GetBackupStorage(ctx context.Context, name string) (*everestv1alpha1.BackupStorage, error) {
+	return c.customClientSet.BackupStorage(c.namespace).Get(ctx, name, metav1.GetOptions{})
+}
+
+// ListBackupStorages returns the backupStorage.
+func (c *Client) ListBackupStorages(ctx context.Context, options metav1.ListOptions) (*everestv1alpha1.BackupStorageList, error) {
+	return c.customClientSet.BackupStorage(c.namespace).List(ctx, options)
+}
+
+// DeleteBackupStorage deletes the backupStorage.
+func (c *Client) DeleteBackupStorage(ctx context.Context, name string) error {
+	return c.customClientSet.BackupStorage(c.namespace).Delete(ctx, name, metav1.DeleteOptions{})
+}

--- a/pkg/kubernetes/client/backup_storage.go
+++ b/pkg/kubernetes/client/backup_storage.go
@@ -36,16 +36,16 @@ func (c *Client) UpdateBackupStorage(ctx context.Context, storage *everestv1alph
 }
 
 // GetBackupStorage returns the backupStorage.
-func (c *Client) GetBackupStorage(ctx context.Context, name string) (*everestv1alpha1.BackupStorage, error) {
-	return c.customClientSet.BackupStorage(c.namespace).Get(ctx, name, metav1.GetOptions{})
+func (c *Client) GetBackupStorage(ctx context.Context, namespace, name string) (*everestv1alpha1.BackupStorage, error) {
+	return c.customClientSet.BackupStorage(namespace).Get(ctx, name, metav1.GetOptions{})
 }
 
 // ListBackupStorages returns the backupStorage.
-func (c *Client) ListBackupStorages(ctx context.Context, options metav1.ListOptions) (*everestv1alpha1.BackupStorageList, error) {
-	return c.customClientSet.BackupStorage(c.namespace).List(ctx, options)
+func (c *Client) ListBackupStorages(ctx context.Context, namespace string, options metav1.ListOptions) (*everestv1alpha1.BackupStorageList, error) {
+	return c.customClientSet.BackupStorage(namespace).List(ctx, options)
 }
 
 // DeleteBackupStorage deletes the backupStorage.
-func (c *Client) DeleteBackupStorage(ctx context.Context, name string) error {
-	return c.customClientSet.BackupStorage(c.namespace).Delete(ctx, name, metav1.DeleteOptions{})
+func (c *Client) DeleteBackupStorage(ctx context.Context, namespace, name string) error {
+	return c.customClientSet.BackupStorage(namespace).Delete(ctx, name, metav1.DeleteOptions{})
 }

--- a/pkg/kubernetes/client/client.go
+++ b/pkg/kubernetes/client/client.go
@@ -224,11 +224,7 @@ func (c *Client) initOperatorClients() error {
 	}
 	c.customClientSet = customClient
 	_, err = c.GetServerVersion()
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 func (c *Client) kubeClient() (client.Client, error) { //nolint:ireturn,nolintlint

--- a/pkg/kubernetes/client/client.go
+++ b/pkg/kubernetes/client/client.go
@@ -1279,9 +1279,9 @@ func (c *Client) GetInstallPlan(ctx context.Context, namespace string, name stri
 }
 
 // DoPackageWait for the package to be available in OLM.
-func (c *Client) DoPackageWait(ctx context.Context, name string) error {
+func (c *Client) DoPackageWait(ctx context.Context, namespace, name string) error {
 	packageInstalled := func(ctx context.Context) (bool, error) {
-		_, err := c.GetPackageManifest(ctx, name)
+		_, err := c.GetPackageManifest(ctx, namespace, name)
 		if err != nil {
 			if apierrors.ReasonForError(err) == metav1.StatusReasonUnknown {
 				return false, err
@@ -1294,8 +1294,7 @@ func (c *Client) DoPackageWait(ctx context.Context, name string) error {
 }
 
 // GetPackageManifest returns a package manifest by given name.
-func (c *Client) GetPackageManifest(ctx context.Context, name string) (*packagev1.PackageManifest, error) {
-	namespace := "olm"
+func (c *Client) GetPackageManifest(ctx context.Context, namespace, name string) (*packagev1.PackageManifest, error) {
 	operatorClient, err := packageServerClient.NewForConfig(c.restConfig)
 	if err != nil {
 		return nil, errors.Join(err, errors.New("cannot create an operator client instance"))

--- a/pkg/kubernetes/client/client.go
+++ b/pkg/kubernetes/client/client.go
@@ -1375,6 +1375,19 @@ func (c *Client) ListClusterServiceVersion(
 	return operatorClient.OperatorsV1alpha1().ClusterServiceVersions(namespace).List(ctx, metav1.ListOptions{})
 }
 
+// DeleteClusterServiceVersion deletes a CSV by namespaced name.
+func (c *Client) DeleteClusterServiceVersion(
+	ctx context.Context,
+	key types.NamespacedName,
+) error {
+	operatorClient, err := versioned.NewForConfig(c.restConfig)
+	if err != nil {
+		return errors.Join(err, errors.New("cannot create an operator client instance"))
+	}
+
+	return operatorClient.OperatorsV1alpha1().ClusterServiceVersions(key.Namespace).Delete(ctx, key.Name, metav1.DeleteOptions{})
+}
+
 // DeleteFile accepts manifest file contents parses into []runtime.Object
 // and deletes them from the cluster.
 func (c *Client) DeleteFile(fileBytes []byte) error {

--- a/pkg/kubernetes/client/client.go
+++ b/pkg/kubernetes/client/client.go
@@ -36,7 +36,6 @@ import (
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
 	packagev1 "github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/apis/operators/v1"
 	packageServerClient "github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/client/clientset/versioned"
-	everestv1alpha1 "github.com/percona/everest-operator/api/v1alpha1"
 	"go.uber.org/zap"
 	"gopkg.in/yaml.v3"
 	appsv1 "k8s.io/api/apps/v1"
@@ -71,6 +70,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 
+	"github.com/percona/percona-everest-cli/pkg/kubernetes/client/customresources"
 	"github.com/percona/percona-everest-cli/pkg/kubernetes/client/database"
 )
 
@@ -101,6 +101,7 @@ type Client struct {
 	l *zap.SugaredLogger
 
 	clientset        kubernetes.Interface
+	customClientSet  *customresources.Client
 	apiextClientset  apiextv1clientset.Interface
 	dynamicClientset dynamic.Interface
 	dbClusterClient  *database.DBClusterClient
@@ -217,13 +218,17 @@ func (c *Client) setup() error {
 
 // Initializes clients for operators.
 func (c *Client) initOperatorClients() error {
-	dbClusterClient, err := database.NewForConfig(c.restConfig)
+	customClient, err := customresources.NewForConfig(c.restConfig)
 	if err != nil {
 		return err
 	}
-	c.dbClusterClient = dbClusterClient
+	c.customClientSet = customClient
 	_, err = c.GetServerVersion()
-	return err
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (c *Client) kubeClient() (client.Client, error) { //nolint:ireturn,nolintlint
@@ -311,20 +316,6 @@ func (c *Client) GenerateKubeConfigWithToken(user string, secret *corev1.Secret)
 // GetServerVersion returns server version.
 func (c *Client) GetServerVersion() (*version.Info, error) {
 	return c.clientset.Discovery().ServerVersion()
-}
-
-// ListDatabaseClusters returns list of managed PCX clusters.
-func (c *Client) ListDatabaseClusters(ctx context.Context) (*everestv1alpha1.DatabaseClusterList, error) {
-	return c.dbClusterClient.DBClusters(c.namespace).List(ctx, metav1.ListOptions{})
-}
-
-// GetDatabaseCluster returns PXC clusters by provided name.
-func (c *Client) GetDatabaseCluster(ctx context.Context, name string) (*everestv1alpha1.DatabaseCluster, error) {
-	cluster, err := c.dbClusterClient.DBClusters(c.namespace).Get(ctx, name, metav1.GetOptions{})
-	if err != nil {
-		return nil, err
-	}
-	return cluster, nil
 }
 
 // GetStorageClasses returns all storage classes available in the cluster.

--- a/pkg/kubernetes/client/customresources/backupstorages.go
+++ b/pkg/kubernetes/client/customresources/backupstorages.go
@@ -1,0 +1,136 @@
+// everest
+// Copyright (C) 2023 Percona LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package customresources provides methods to work with custom everest k8s resources.
+//
+//nolint:dupl
+package customresources
+
+import (
+	"context"
+
+	everestv1alpha1 "github.com/percona/everest-operator/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+)
+
+const (
+	backupStorageAPIKind = "backupstorages"
+)
+
+// BackupStorage returns a db cluster client.
+func (c *Client) BackupStorage( //nolint:ireturn
+	namespace string,
+) BackupStoragesInterface {
+	return &client{
+		restClient: c.restClient,
+		namespace:  namespace,
+	}
+}
+
+// BackupStoragesInterface supports methods to work with BackupStorages.
+type BackupStoragesInterface interface {
+	List(ctx context.Context, opts metav1.ListOptions) (*everestv1alpha1.BackupStorageList, error)
+	Create(ctx context.Context, storage *everestv1alpha1.BackupStorage, opts metav1.CreateOptions) (*everestv1alpha1.BackupStorage, error)
+	Update(ctx context.Context, storage *everestv1alpha1.BackupStorage, opts metav1.UpdateOptions) (*everestv1alpha1.BackupStorage, error)
+	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	Get(ctx context.Context, name string, opts metav1.GetOptions) (*everestv1alpha1.BackupStorage, error)
+}
+
+type client struct {
+	restClient rest.Interface
+	namespace  string
+}
+
+// Create creates a resource.
+func (c *client) Create(
+	ctx context.Context,
+	storage *everestv1alpha1.BackupStorage,
+	opts metav1.CreateOptions,
+) (*everestv1alpha1.BackupStorage, error) {
+	result := &everestv1alpha1.BackupStorage{}
+	err := c.restClient.
+		Post().
+		Namespace(c.namespace).
+		Resource(backupStorageAPIKind).Body(storage).
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do(ctx).Into(result)
+	return result, err
+}
+
+// Update creates a resource.
+func (c *client) Update(
+	ctx context.Context,
+	storage *everestv1alpha1.BackupStorage,
+	opts metav1.UpdateOptions,
+) (*everestv1alpha1.BackupStorage, error) {
+	result := &everestv1alpha1.BackupStorage{}
+	err := c.restClient.
+		Put().Name(storage.Name).
+		Namespace(c.namespace).
+		Resource(backupStorageAPIKind).Body(storage).
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do(ctx).Into(result)
+	return result, err
+}
+
+// Delete creates a resource.
+func (c *client) Delete(
+	ctx context.Context,
+	name string,
+	opts metav1.DeleteOptions,
+) error {
+	return c.restClient.
+		Delete().Name(name).
+		Namespace(c.namespace).
+		Resource(backupStorageAPIKind).
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do(ctx).Error()
+}
+
+// Get retrieves backup storage based on opts.
+func (c *client) Get(
+	ctx context.Context,
+	name string,
+	opts metav1.GetOptions,
+) (*everestv1alpha1.BackupStorage, error) {
+	result := &everestv1alpha1.BackupStorage{}
+	err := c.restClient.
+		Get().
+		Namespace(c.namespace).
+		Resource(backupStorageAPIKind).
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Name(name).
+		Do(ctx).
+		Into(result)
+	return result, err
+}
+
+// List retrieves backup storage list based on opts.
+func (c *client) List(
+	ctx context.Context,
+	opts metav1.ListOptions,
+) (*everestv1alpha1.BackupStorageList, error) {
+	result := &everestv1alpha1.BackupStorageList{}
+	err := c.restClient.
+		Get().
+		Namespace(c.namespace).
+		Resource(backupStorageAPIKind).
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do(ctx).
+		Into(result)
+	return result, err
+}

--- a/pkg/kubernetes/client/customresources/client.go
+++ b/pkg/kubernetes/client/customresources/client.go
@@ -1,0 +1,62 @@
+// everest
+// Copyright (C) 2023 Percona LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package customresources provides methods to work with custom everest k8s resources.
+package customresources
+
+import (
+	"sync"
+
+	everestv1alpha1 "github.com/percona/everest-operator/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+)
+
+//nolint:gochecknoglobals
+var addToScheme sync.Once
+
+// Client contains a rest client.
+type Client struct {
+	restClient rest.Interface
+}
+
+// NewForConfig creates a new database cluster client based on config.
+func NewForConfig(c *rest.Config) (*Client, error) {
+	config := *c
+	config.ContentConfig.GroupVersion = &everestv1alpha1.GroupVersion
+	config.APIPath = "/apis"
+	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	config.UserAgent = rest.DefaultKubernetesUserAgent()
+
+	var err error
+	addToScheme.Do(func() {
+		err = everestv1alpha1.SchemeBuilder.AddToScheme(scheme.Scheme)
+		metav1.AddToGroupVersion(scheme.Scheme, everestv1alpha1.GroupVersion)
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := rest.RESTClientFor(&config)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Client{
+		restClient: client,
+	}, nil
+}

--- a/pkg/kubernetes/client/customresources/database_cluster_backups.go
+++ b/pkg/kubernetes/client/customresources/database_cluster_backups.go
@@ -1,0 +1,97 @@
+// Package customresources ...
+// everest
+// Copyright (C) 2023 Percona LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//nolint:dupl
+package customresources
+
+import (
+	"context"
+
+	everestv1alpha1 "github.com/percona/everest-operator/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+)
+
+const (
+	dbClusterBackupsAPIKind = "databaseclusterbackups"
+)
+
+// DBClusterBackups returns a db cluster backup.
+func (c *Client) DBClusterBackups(namespace string) DBClusterBackupInterface { //nolint:ireturn
+	return &dbClusterBackupClient{
+		restClient: c.restClient,
+		namespace:  namespace,
+	}
+}
+
+type dbClusterBackupClient struct {
+	restClient rest.Interface
+	namespace  string
+}
+
+// DBClusterBackupInterface supports list, get and watch methods.
+type DBClusterBackupInterface interface {
+	List(ctx context.Context, opts metav1.ListOptions) (*everestv1alpha1.DatabaseClusterBackupList, error)
+	Get(ctx context.Context, name string, options metav1.GetOptions) (*everestv1alpha1.DatabaseClusterBackup, error)
+	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)
+}
+
+// List lists database cluster backups based on opts.
+func (c *dbClusterBackupClient) List(ctx context.Context, opts metav1.ListOptions) (*everestv1alpha1.DatabaseClusterBackupList, error) {
+	result := &everestv1alpha1.DatabaseClusterBackupList{}
+	err := c.restClient.
+		Get().
+		Namespace(c.namespace).
+		Resource(dbClusterBackupsAPIKind).
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do(ctx).
+		Into(result)
+	return result, err
+}
+
+// Get retrieves database cluster backup based on opts.
+func (c *dbClusterBackupClient) Get(
+	ctx context.Context,
+	name string,
+	opts metav1.GetOptions,
+) (*everestv1alpha1.DatabaseClusterBackup, error) {
+	result := &everestv1alpha1.DatabaseClusterBackup{}
+	err := c.restClient.
+		Get().
+		Namespace(c.namespace).
+		Resource(dbClusterBackupsAPIKind).
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Name(name).
+		Do(ctx).
+		Into(result)
+	return result, err
+}
+
+// Watch starts a watch based on opts.
+func (c *dbClusterBackupClient) Watch( //nolint:ireturn
+	ctx context.Context,
+	opts metav1.ListOptions,
+) (watch.Interface, error) {
+	opts.Watch = true
+	return c.restClient.
+		Get().
+		Namespace(c.namespace).
+		Resource(dbClusterBackupsAPIKind).
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch(ctx)
+}

--- a/pkg/kubernetes/client/customresources/database_cluster_restores.go
+++ b/pkg/kubernetes/client/customresources/database_cluster_restores.go
@@ -1,0 +1,97 @@
+// Package customresources ...
+// everest
+// Copyright (C) 2023 Percona LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//nolint:dupl
+package customresources
+
+import (
+	"context"
+
+	everestv1alpha1 "github.com/percona/everest-operator/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+)
+
+const (
+	dbClusterRestoresAPIKind = "databaseclusterrestores"
+)
+
+// DBClusterRestores returns a db cluster client.
+func (c *Client) DBClusterRestores(namespace string) DBClusterRestoreInterface { //nolint:ireturn
+	return &dbClusterRestoreClient{
+		restClient: c.restClient,
+		namespace:  namespace,
+	}
+}
+
+type dbClusterRestoreClient struct {
+	restClient rest.Interface
+	namespace  string
+}
+
+// DBClusterRestoreInterface supports list, get and watch methods.
+type DBClusterRestoreInterface interface {
+	List(ctx context.Context, opts metav1.ListOptions) (*everestv1alpha1.DatabaseClusterRestoreList, error)
+	Get(ctx context.Context, name string, options metav1.GetOptions) (*everestv1alpha1.DatabaseClusterRestore, error)
+	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)
+}
+
+// List lists database cluster restores based on opts.
+func (c *dbClusterRestoreClient) List(ctx context.Context, opts metav1.ListOptions) (*everestv1alpha1.DatabaseClusterRestoreList, error) {
+	result := &everestv1alpha1.DatabaseClusterRestoreList{}
+	err := c.restClient.
+		Get().
+		Namespace(c.namespace).
+		Resource(dbClusterRestoresAPIKind).
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do(ctx).
+		Into(result)
+	return result, err
+}
+
+// Get retrieves database cluster restore based on opts.
+func (c *dbClusterRestoreClient) Get(
+	ctx context.Context,
+	name string,
+	opts metav1.GetOptions,
+) (*everestv1alpha1.DatabaseClusterRestore, error) {
+	result := &everestv1alpha1.DatabaseClusterRestore{}
+	err := c.restClient.
+		Get().
+		Namespace(c.namespace).
+		Resource(dbClusterRestoresAPIKind).
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Name(name).
+		Do(ctx).
+		Into(result)
+	return result, err
+}
+
+// Watch starts a watch based on opts.
+func (c *dbClusterRestoreClient) Watch( //nolint:ireturn
+	ctx context.Context,
+	opts metav1.ListOptions,
+) (watch.Interface, error) {
+	opts.Watch = true
+	return c.restClient.
+		Get().
+		Namespace(c.namespace).
+		Resource(dbClusterRestoresAPIKind).
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch(ctx)
+}

--- a/pkg/kubernetes/client/customresources/databaseclusters.go
+++ b/pkg/kubernetes/client/customresources/databaseclusters.go
@@ -1,0 +1,97 @@
+// Package customresources ...
+// everest
+// Copyright (C) 2023 Percona LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//nolint:dupl
+package customresources
+
+import (
+	"context"
+
+	everestv1alpha1 "github.com/percona/everest-operator/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+)
+
+const (
+	dbClustersAPIKind = "databaseclusters"
+)
+
+// DBClusters returns a db cluster client.
+func (c *Client) DBClusters(namespace string) DBClusterInterface { //nolint:ireturn
+	return &dbClusterClient{
+		restClient: c.restClient,
+		namespace:  namespace,
+	}
+}
+
+type dbClusterClient struct {
+	restClient rest.Interface
+	namespace  string
+}
+
+// DBClusterInterface supports list, get and watch methods.
+type DBClusterInterface interface {
+	List(ctx context.Context, opts metav1.ListOptions) (*everestv1alpha1.DatabaseClusterList, error)
+	Get(ctx context.Context, name string, options metav1.GetOptions) (*everestv1alpha1.DatabaseCluster, error)
+	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)
+}
+
+// List lists database clusters based on opts.
+func (c *dbClusterClient) List(ctx context.Context, opts metav1.ListOptions) (*everestv1alpha1.DatabaseClusterList, error) {
+	result := &everestv1alpha1.DatabaseClusterList{}
+	err := c.restClient.
+		Get().
+		Namespace(c.namespace).
+		Resource(dbClustersAPIKind).
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do(ctx).
+		Into(result)
+	return result, err
+}
+
+// Get retrieves database cluster based on opts.
+func (c *dbClusterClient) Get(
+	ctx context.Context,
+	name string,
+	opts metav1.GetOptions,
+) (*everestv1alpha1.DatabaseCluster, error) {
+	result := &everestv1alpha1.DatabaseCluster{}
+	err := c.restClient.
+		Get().
+		Namespace(c.namespace).
+		Resource(dbClustersAPIKind).
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Name(name).
+		Do(ctx).
+		Into(result)
+	return result, err
+}
+
+// Watch starts a watch based on opts.
+func (c *dbClusterClient) Watch( //nolint:ireturn
+	ctx context.Context,
+	opts metav1.ListOptions,
+) (watch.Interface, error) {
+	opts.Watch = true
+	return c.restClient.
+		Get().
+		Namespace(c.namespace).
+		Resource(dbClustersAPIKind).
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch(ctx)
+}

--- a/pkg/kubernetes/client/customresources/databaseengines.go
+++ b/pkg/kubernetes/client/customresources/databaseengines.go
@@ -1,0 +1,97 @@
+// Package customresources ...
+// everest
+// Copyright (C) 2023 Percona LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//nolint:dupl
+package customresources
+
+import (
+	"context"
+
+	everestv1alpha1 "github.com/percona/everest-operator/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+)
+
+const (
+	dbEnginesAPIKind = "databaseengines"
+)
+
+// DBEngines returns a db engine.
+func (c *Client) DBEngines(namespace string) DBEngineInterface { //nolint:ireturn
+	return &dbEngineClient{
+		restClient: c.restClient,
+		namespace:  namespace,
+	}
+}
+
+type dbEngineClient struct {
+	restClient rest.Interface
+	namespace  string
+}
+
+// DBEngineInterface supports list, get and watch methods.
+type DBEngineInterface interface {
+	List(ctx context.Context, opts metav1.ListOptions) (*everestv1alpha1.DatabaseEngineList, error)
+	Get(ctx context.Context, name string, options metav1.GetOptions) (*everestv1alpha1.DatabaseEngine, error)
+	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)
+}
+
+// List lists database clusters based on opts.
+func (c *dbEngineClient) List(ctx context.Context, opts metav1.ListOptions) (*everestv1alpha1.DatabaseEngineList, error) {
+	result := &everestv1alpha1.DatabaseEngineList{}
+	err := c.restClient.
+		Get().
+		Namespace(c.namespace).
+		Resource(dbEnginesAPIKind).
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do(ctx).
+		Into(result)
+	return result, err
+}
+
+// Get retrieves database cluster based on opts.
+func (c *dbEngineClient) Get(
+	ctx context.Context,
+	name string,
+	opts metav1.GetOptions,
+) (*everestv1alpha1.DatabaseEngine, error) {
+	result := &everestv1alpha1.DatabaseEngine{}
+	err := c.restClient.
+		Get().
+		Namespace(c.namespace).
+		Resource(dbEnginesAPIKind).
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Name(name).
+		Do(ctx).
+		Into(result)
+	return result, err
+}
+
+// Watch starts a watch based on opts.
+func (c *dbEngineClient) Watch( //nolint:ireturn
+	ctx context.Context,
+	opts metav1.ListOptions,
+) (watch.Interface, error) {
+	opts.Watch = true
+	return c.restClient.
+		Get().
+		Namespace(c.namespace).
+		Resource(dbEnginesAPIKind).
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch(ctx)
+}

--- a/pkg/kubernetes/client/customresources/monitoringconfigs.go
+++ b/pkg/kubernetes/client/customresources/monitoringconfigs.go
@@ -1,0 +1,136 @@
+// everest
+// Copyright (C) 2023 Percona LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package customresources provides methods to work with custom everest k8s resources.
+//
+//nolint:dupl
+package customresources
+
+import (
+	"context"
+
+	everestv1alpha1 "github.com/percona/everest-operator/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+)
+
+const (
+	monitoringConfigAPIKind = "monitoringconfigs"
+)
+
+// MonitoringConfig returns a db cluster monitoringConfigClient.
+func (c *Client) MonitoringConfig( //nolint:ireturn
+	namespace string,
+) MonitoringConfigsInterface {
+	return &monitoringConfigClient{
+		restClient: c.restClient,
+		namespace:  namespace,
+	}
+}
+
+// MonitoringConfigsInterface supports methods to work with MonitoringConfigs.
+type MonitoringConfigsInterface interface {
+	List(ctx context.Context, opts metav1.ListOptions) (*everestv1alpha1.MonitoringConfigList, error)
+	Create(ctx context.Context, storage *everestv1alpha1.MonitoringConfig, opts metav1.CreateOptions) (*everestv1alpha1.MonitoringConfig, error)
+	Update(ctx context.Context, storage *everestv1alpha1.MonitoringConfig, opts metav1.UpdateOptions) (*everestv1alpha1.MonitoringConfig, error)
+	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	Get(ctx context.Context, name string, opts metav1.GetOptions) (*everestv1alpha1.MonitoringConfig, error)
+}
+
+type monitoringConfigClient struct {
+	restClient rest.Interface
+	namespace  string
+}
+
+// Create creates a monitoring config.
+func (c *monitoringConfigClient) Create(
+	ctx context.Context,
+	storage *everestv1alpha1.MonitoringConfig,
+	opts metav1.CreateOptions,
+) (*everestv1alpha1.MonitoringConfig, error) {
+	result := &everestv1alpha1.MonitoringConfig{}
+	err := c.restClient.
+		Post().
+		Namespace(c.namespace).
+		Resource(monitoringConfigAPIKind).Body(storage).
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do(ctx).Into(result)
+	return result, err
+}
+
+// Update updates a monitoring config.
+func (c *monitoringConfigClient) Update(
+	ctx context.Context,
+	storage *everestv1alpha1.MonitoringConfig,
+	opts metav1.UpdateOptions,
+) (*everestv1alpha1.MonitoringConfig, error) {
+	result := &everestv1alpha1.MonitoringConfig{}
+	err := c.restClient.
+		Put().Name(storage.Name).
+		Namespace(c.namespace).
+		Resource(monitoringConfigAPIKind).Body(storage).
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do(ctx).Into(result)
+	return result, err
+}
+
+// Delete creates a resource.
+func (c *monitoringConfigClient) Delete(
+	ctx context.Context,
+	name string,
+	opts metav1.DeleteOptions,
+) error {
+	return c.restClient.
+		Delete().Name(name).
+		Namespace(c.namespace).
+		Resource(monitoringConfigAPIKind).
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do(ctx).Error()
+}
+
+// Get retrieves a monitoring config based on opts.
+func (c *monitoringConfigClient) Get(
+	ctx context.Context,
+	name string,
+	opts metav1.GetOptions,
+) (*everestv1alpha1.MonitoringConfig, error) {
+	result := &everestv1alpha1.MonitoringConfig{}
+	err := c.restClient.
+		Get().
+		Namespace(c.namespace).
+		Resource(monitoringConfigAPIKind).
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Name(name).
+		Do(ctx).
+		Into(result)
+	return result, err
+}
+
+// List retrieves a monitoring configs list based on opts.
+func (c *monitoringConfigClient) List(
+	ctx context.Context,
+	opts metav1.ListOptions,
+) (*everestv1alpha1.MonitoringConfigList, error) {
+	result := &everestv1alpha1.MonitoringConfigList{}
+	err := c.restClient.
+		Get().
+		Namespace(c.namespace).
+		Resource(monitoringConfigAPIKind).
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do(ctx).
+		Into(result)
+	return result, err
+}

--- a/pkg/kubernetes/client/database_cluster.go
+++ b/pkg/kubernetes/client/database_cluster.go
@@ -1,0 +1,18 @@
+package client
+
+import (
+	"context"
+
+	everestv1alpha1 "github.com/percona/everest-operator/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ListDatabaseClusters returns list of managed database clusters.
+func (c *Client) ListDatabaseClusters(ctx context.Context, namespace string, options metav1.ListOptions) (*everestv1alpha1.DatabaseClusterList, error) {
+	return c.customClientSet.DBClusters(namespace).List(ctx, options)
+}
+
+// GetDatabaseCluster returns database clusters by provided name.
+func (c *Client) GetDatabaseCluster(ctx context.Context, namespace, name string) (*everestv1alpha1.DatabaseCluster, error) {
+	return c.customClientSet.DBClusters(namespace).Get(ctx, name, metav1.GetOptions{})
+}

--- a/pkg/kubernetes/client/database_cluster_backup.go
+++ b/pkg/kubernetes/client/database_cluster_backup.go
@@ -1,0 +1,18 @@
+package client
+
+import (
+	"context"
+
+	everestv1alpha1 "github.com/percona/everest-operator/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ListDatabaseClusterBackups returns list of managed database cluster backups.
+func (c *Client) ListDatabaseClusterBackups(ctx context.Context, namespace string, options metav1.ListOptions) (*everestv1alpha1.DatabaseClusterBackupList, error) {
+	return c.customClientSet.DBClusterBackups(namespace).List(ctx, options)
+}
+
+// GetDatabaseClusterBackup returns database cluster backups by provided name.
+func (c *Client) GetDatabaseClusterBackup(ctx context.Context, namespace, name string) (*everestv1alpha1.DatabaseClusterBackup, error) {
+	return c.customClientSet.DBClusterBackups(namespace).Get(ctx, name, metav1.GetOptions{})
+}

--- a/pkg/kubernetes/client/database_cluster_restore.go
+++ b/pkg/kubernetes/client/database_cluster_restore.go
@@ -1,0 +1,18 @@
+package client
+
+import (
+	"context"
+
+	everestv1alpha1 "github.com/percona/everest-operator/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ListDatabaseClusterRestores returns list of managed database clusters.
+func (c *Client) ListDatabaseClusterRestores(ctx context.Context, namespace string, options metav1.ListOptions) (*everestv1alpha1.DatabaseClusterRestoreList, error) {
+	return c.customClientSet.DBClusterRestores(namespace).List(ctx, options)
+}
+
+// GetDatabaseClusterRestore returns database clusters by provided name.
+func (c *Client) GetDatabaseClusterRestore(ctx context.Context, namespace, name string) (*everestv1alpha1.DatabaseClusterRestore, error) {
+	return c.customClientSet.DBClusterRestores(namespace).Get(ctx, name, metav1.GetOptions{})
+}

--- a/pkg/kubernetes/client/database_engine.go
+++ b/pkg/kubernetes/client/database_engine.go
@@ -1,0 +1,18 @@
+package client
+
+import (
+	"context"
+
+	everestv1alpha1 "github.com/percona/everest-operator/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ListDatabaseEngines returns list of managed database clusters.
+func (c *Client) ListDatabaseEngines(ctx context.Context, namespace string) (*everestv1alpha1.DatabaseEngineList, error) {
+	return c.customClientSet.DBEngines(namespace).List(ctx, metav1.ListOptions{})
+}
+
+// GetDatabaseEngine returns database clusters by provided name.
+func (c *Client) GetDatabaseEngine(ctx context.Context, namespace, name string) (*everestv1alpha1.DatabaseEngine, error) {
+	return c.customClientSet.DBEngines(namespace).Get(ctx, name, metav1.GetOptions{})
+}

--- a/pkg/kubernetes/client/gen.go
+++ b/pkg/kubernetes/client/gen.go
@@ -15,5 +15,5 @@
 
 package client
 
-//go:generate ../../../bin/ifacemaker -f client.go -f monitoring.go -f namespace.go -s Client -i KubeClientConnector -p client -o kubeclient_interface.go
+//go:generate ../../../bin/ifacemaker -f backup_storage.go -f client.go -f database_cluster.go -f database_cluster_backup.go -f database_cluster_restore.go -f database_engine.go -f monitoring.go -f monitoring_config.go -f namespace.go -s Client -i KubeClientConnector -p client -o kubeclient_interface.go
 //go:generate ../../../bin/mockery --name=KubeClientConnector --case=snake --inpackage

--- a/pkg/kubernetes/client/kubeclient_interface.go
+++ b/pkg/kubernetes/client/kubeclient_interface.go
@@ -108,9 +108,9 @@ type KubeClientConnector interface {
 	// GetInstallPlan retrieves an OLM install plan by namespace and name.
 	GetInstallPlan(ctx context.Context, namespace string, name string) (*v1alpha1.InstallPlan, error)
 	// DoPackageWait for the package to be available in OLM.
-	DoPackageWait(ctx context.Context, name string) error
+	DoPackageWait(ctx context.Context, namespace, name string) error
 	// GetPackageManifest returns a package manifest by given name.
-	GetPackageManifest(ctx context.Context, name string) (*packagev1.PackageManifest, error)
+	GetPackageManifest(ctx context.Context, namespace, name string) (*packagev1.PackageManifest, error)
 	// UpdateInstallPlan updates the existing install plan in the specified namespace.
 	UpdateInstallPlan(ctx context.Context, namespace string, installPlan *v1alpha1.InstallPlan) (*v1alpha1.InstallPlan, error)
 	// ListCRDs returns a list of CRDs.

--- a/pkg/kubernetes/client/kubeclient_interface.go
+++ b/pkg/kubernetes/client/kubeclient_interface.go
@@ -31,11 +31,11 @@ type KubeClientConnector interface {
 	// UpdateBackupStorage updates an backupStorage.
 	UpdateBackupStorage(ctx context.Context, storage *everestv1alpha1.BackupStorage) error
 	// GetBackupStorage returns the backupStorage.
-	GetBackupStorage(ctx context.Context, name string) (*everestv1alpha1.BackupStorage, error)
+	GetBackupStorage(ctx context.Context, namespace, name string) (*everestv1alpha1.BackupStorage, error)
 	// ListBackupStorages returns the backupStorage.
-	ListBackupStorages(ctx context.Context, options metav1.ListOptions) (*everestv1alpha1.BackupStorageList, error)
+	ListBackupStorages(ctx context.Context, namespace string, options metav1.ListOptions) (*everestv1alpha1.BackupStorageList, error)
 	// DeleteBackupStorage deletes the backupStorage.
-	DeleteBackupStorage(ctx context.Context, name string) error
+	DeleteBackupStorage(ctx context.Context, namespace, name string) error
 	// ClusterName returns the name of the k8s cluster.
 	ClusterName() string
 	// GetSecretsForServiceAccount returns secret by given service account name.

--- a/pkg/kubernetes/client/kubeclient_interface.go
+++ b/pkg/kubernetes/client/kubeclient_interface.go
@@ -146,6 +146,16 @@ type KubeClientConnector interface {
 	GetDatabaseEngine(ctx context.Context, namespace, name string) (*everestv1alpha1.DatabaseEngine, error)
 	// DeleteAllMonitoringResources deletes all resources related to monitoring from k8s cluster.
 	DeleteAllMonitoringResources(ctx context.Context, namespace string) error
+	// CreateMonitoringConfig creates an monitoringConfig.
+	CreateMonitoringConfig(ctx context.Context, config *everestv1alpha1.MonitoringConfig) error
+	// UpdateMonitoringConfig updates an monitoringConfig.
+	UpdateMonitoringConfig(ctx context.Context, config *everestv1alpha1.MonitoringConfig) error
+	// GetMonitoringConfig returns the monitoringConfig.
+	GetMonitoringConfig(ctx context.Context, namespace, name string) (*everestv1alpha1.MonitoringConfig, error)
+	// ListMonitoringConfigs returns the monitoringConfig.
+	ListMonitoringConfigs(ctx context.Context, namespace string) (*everestv1alpha1.MonitoringConfigList, error)
+	// DeleteMonitoringConfig deletes the monitoringConfig.
+	DeleteMonitoringConfig(ctx context.Context, namespace, name string) error
 	// GetNamespace returns a namespace.
 	GetNamespace(ctx context.Context, name string) (*corev1.Namespace, error)
 	// DeleteNamespace deletes a namespace.

--- a/pkg/kubernetes/client/kubeclient_interface.go
+++ b/pkg/kubernetes/client/kubeclient_interface.go
@@ -121,6 +121,8 @@ type KubeClientConnector interface {
 	GetClusterServiceVersion(ctx context.Context, key types.NamespacedName) (*v1alpha1.ClusterServiceVersion, error)
 	// ListClusterServiceVersion list all CSVs for the given namespace.
 	ListClusterServiceVersion(ctx context.Context, namespace string) (*v1alpha1.ClusterServiceVersionList, error)
+	// DeleteClusterServiceVersion deletes a CSV by namespaced name.
+	DeleteClusterServiceVersion(ctx context.Context, key types.NamespacedName) error
 	// DeleteFile accepts manifest file contents parses into []runtime.Object
 	// and deletes them from the cluster.
 	DeleteFile(fileBytes []byte) error

--- a/pkg/kubernetes/client/kubeclient_interface.go
+++ b/pkg/kubernetes/client/kubeclient_interface.go
@@ -26,6 +26,16 @@ import (
 
 // KubeClientConnector ...
 type KubeClientConnector interface {
+	// CreateBackupStorage creates an backupStorage.
+	CreateBackupStorage(ctx context.Context, storage *everestv1alpha1.BackupStorage) error
+	// UpdateBackupStorage updates an backupStorage.
+	UpdateBackupStorage(ctx context.Context, storage *everestv1alpha1.BackupStorage) error
+	// GetBackupStorage returns the backupStorage.
+	GetBackupStorage(ctx context.Context, name string) (*everestv1alpha1.BackupStorage, error)
+	// ListBackupStorages returns the backupStorage.
+	ListBackupStorages(ctx context.Context, options metav1.ListOptions) (*everestv1alpha1.BackupStorageList, error)
+	// DeleteBackupStorage deletes the backupStorage.
+	DeleteBackupStorage(ctx context.Context, name string) error
 	// ClusterName returns the name of the k8s cluster.
 	ClusterName() string
 	// GetSecretsForServiceAccount returns secret by given service account name.
@@ -34,10 +44,6 @@ type KubeClientConnector interface {
 	GenerateKubeConfigWithToken(user string, secret *corev1.Secret) ([]byte, error)
 	// GetServerVersion returns server version.
 	GetServerVersion() (*version.Info, error)
-	// ListDatabaseClusters returns list of managed PCX clusters.
-	ListDatabaseClusters(ctx context.Context) (*everestv1alpha1.DatabaseClusterList, error)
-	// GetDatabaseCluster returns PXC clusters by provided name.
-	GetDatabaseCluster(ctx context.Context, name string) (*everestv1alpha1.DatabaseCluster, error)
 	// GetStorageClasses returns all storage classes available in the cluster.
 	GetStorageClasses(ctx context.Context) (*storagev1.StorageClassList, error)
 	// GetDeployment returns deployment by name.
@@ -122,6 +128,22 @@ type KubeClientConnector interface {
 	GetService(ctx context.Context, namespace, name string) (*corev1.Service, error)
 	// GetClusterRoleBinding returns cluster role binding by given name.
 	GetClusterRoleBinding(ctx context.Context, name string) (*rbacv1.ClusterRoleBinding, error)
+	// ListDatabaseClusters returns list of managed database clusters.
+	ListDatabaseClusters(ctx context.Context, namespace string, options metav1.ListOptions) (*everestv1alpha1.DatabaseClusterList, error)
+	// GetDatabaseCluster returns database clusters by provided name.
+	GetDatabaseCluster(ctx context.Context, namespace, name string) (*everestv1alpha1.DatabaseCluster, error)
+	// ListDatabaseClusterBackups returns list of managed database cluster backups.
+	ListDatabaseClusterBackups(ctx context.Context, namespace string, options metav1.ListOptions) (*everestv1alpha1.DatabaseClusterBackupList, error)
+	// GetDatabaseClusterBackup returns database cluster backups by provided name.
+	GetDatabaseClusterBackup(ctx context.Context, namespace, name string) (*everestv1alpha1.DatabaseClusterBackup, error)
+	// ListDatabaseClusterRestores returns list of managed database clusters.
+	ListDatabaseClusterRestores(ctx context.Context, namespace string, options metav1.ListOptions) (*everestv1alpha1.DatabaseClusterRestoreList, error)
+	// GetDatabaseClusterRestore returns database clusters by provided name.
+	GetDatabaseClusterRestore(ctx context.Context, namespace, name string) (*everestv1alpha1.DatabaseClusterRestore, error)
+	// ListDatabaseEngines returns list of managed database clusters.
+	ListDatabaseEngines(ctx context.Context, namespace string) (*everestv1alpha1.DatabaseEngineList, error)
+	// GetDatabaseEngine returns database clusters by provided name.
+	GetDatabaseEngine(ctx context.Context, namespace, name string) (*everestv1alpha1.DatabaseEngine, error)
 	// DeleteAllMonitoringResources deletes all resources related to monitoring from k8s cluster.
 	DeleteAllMonitoringResources(ctx context.Context, namespace string) error
 	// GetNamespace returns a namespace.

--- a/pkg/kubernetes/client/kubeclient_interface.go
+++ b/pkg/kubernetes/client/kubeclient_interface.go
@@ -148,4 +148,6 @@ type KubeClientConnector interface {
 	DeleteAllMonitoringResources(ctx context.Context, namespace string) error
 	// GetNamespace returns a namespace.
 	GetNamespace(ctx context.Context, name string) (*corev1.Namespace, error)
+	// DeleteNamespace deletes a namespace.
+	DeleteNamespace(ctx context.Context, name string) error
 }

--- a/pkg/kubernetes/client/mock_kube_client_connector.go
+++ b/pkg/kubernetes/client/mock_kube_client_connector.go
@@ -445,17 +445,17 @@ func (_m *MockKubeClientConnector) DoCSVWait(ctx context.Context, key types.Name
 	return r0
 }
 
-// DoPackageWait provides a mock function with given fields: ctx, name
-func (_m *MockKubeClientConnector) DoPackageWait(ctx context.Context, name string) error {
-	ret := _m.Called(ctx, name)
+// DoPackageWait provides a mock function with given fields: ctx, namespace, name
+func (_m *MockKubeClientConnector) DoPackageWait(ctx context.Context, namespace string, name string) error {
+	ret := _m.Called(ctx, namespace, name)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DoPackageWait")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
-		r0 = rf(ctx, name)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
+		r0 = rf(ctx, namespace, name)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -957,9 +957,9 @@ func (_m *MockKubeClientConnector) GetOperatorGroup(ctx context.Context, namespa
 	return r0, r1
 }
 
-// GetPackageManifest provides a mock function with given fields: ctx, name
-func (_m *MockKubeClientConnector) GetPackageManifest(ctx context.Context, name string) (*operatorsv1.PackageManifest, error) {
-	ret := _m.Called(ctx, name)
+// GetPackageManifest provides a mock function with given fields: ctx, namespace, name
+func (_m *MockKubeClientConnector) GetPackageManifest(ctx context.Context, namespace string, name string) (*operatorsv1.PackageManifest, error) {
+	ret := _m.Called(ctx, namespace, name)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetPackageManifest")
@@ -967,19 +967,19 @@ func (_m *MockKubeClientConnector) GetPackageManifest(ctx context.Context, name 
 
 	var r0 *operatorsv1.PackageManifest
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string) (*operatorsv1.PackageManifest, error)); ok {
-		return rf(ctx, name)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) (*operatorsv1.PackageManifest, error)); ok {
+		return rf(ctx, namespace, name)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string) *operatorsv1.PackageManifest); ok {
-		r0 = rf(ctx, name)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) *operatorsv1.PackageManifest); ok {
+		r0 = rf(ctx, namespace, name)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*operatorsv1.PackageManifest)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
-		r1 = rf(ctx, name)
+	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = rf(ctx, namespace, name)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/kubernetes/client/mock_kube_client_connector.go
+++ b/pkg/kubernetes/client/mock_kube_client_connector.go
@@ -319,6 +319,24 @@ func (_m *MockKubeClientConnector) DeleteManifestFile(fileBytes []byte, namespac
 	return r0
 }
 
+// DeleteNamespace provides a mock function with given fields: ctx, name
+func (_m *MockKubeClientConnector) DeleteNamespace(ctx context.Context, name string) error {
+	ret := _m.Called(ctx, name)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteNamespace")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = rf(ctx, name)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // DeleteObject provides a mock function with given fields: obj
 func (_m *MockKubeClientConnector) DeleteObject(obj runtime.Object) error {
 	ret := _m.Called(obj)

--- a/pkg/kubernetes/client/mock_kube_client_connector.go
+++ b/pkg/kubernetes/client/mock_kube_client_connector.go
@@ -6,9 +6,9 @@ import (
 	context "context"
 
 	v1 "github.com/operator-framework/api/pkg/operators/v1"
-	v1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	operatorsv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/apis/operators/v1"
-	apiv1alpha1 "github.com/percona/everest-operator/api/v1alpha1"
+	v1alpha1 "github.com/percona/everest-operator/api/v1alpha1"
 	mock "github.com/stretchr/testify/mock"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -121,6 +121,24 @@ func (_m *MockKubeClientConnector) Config() *rest.Config {
 	return r0
 }
 
+// CreateBackupStorage provides a mock function with given fields: ctx, storage
+func (_m *MockKubeClientConnector) CreateBackupStorage(ctx context.Context, storage *v1alpha1.BackupStorage) error {
+	ret := _m.Called(ctx, storage)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateBackupStorage")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, *v1alpha1.BackupStorage) error); ok {
+		r0 = rf(ctx, storage)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // CreateNamespace provides a mock function with given fields: name
 func (_m *MockKubeClientConnector) CreateNamespace(name string) error {
 	ret := _m.Called(name)
@@ -170,27 +188,27 @@ func (_m *MockKubeClientConnector) CreateOperatorGroup(ctx context.Context, name
 }
 
 // CreateSubscription provides a mock function with given fields: ctx, namespace, subscription
-func (_m *MockKubeClientConnector) CreateSubscription(ctx context.Context, namespace string, subscription *v1alpha1.Subscription) (*v1alpha1.Subscription, error) {
+func (_m *MockKubeClientConnector) CreateSubscription(ctx context.Context, namespace string, subscription *operatorsv1alpha1.Subscription) (*operatorsv1alpha1.Subscription, error) {
 	ret := _m.Called(ctx, namespace, subscription)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CreateSubscription")
 	}
 
-	var r0 *v1alpha1.Subscription
+	var r0 *operatorsv1alpha1.Subscription
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, *v1alpha1.Subscription) (*v1alpha1.Subscription, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string, *operatorsv1alpha1.Subscription) (*operatorsv1alpha1.Subscription, error)); ok {
 		return rf(ctx, namespace, subscription)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, *v1alpha1.Subscription) *v1alpha1.Subscription); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string, *operatorsv1alpha1.Subscription) *operatorsv1alpha1.Subscription); ok {
 		r0 = rf(ctx, namespace, subscription)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*v1alpha1.Subscription)
+			r0 = ret.Get(0).(*operatorsv1alpha1.Subscription)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, *v1alpha1.Subscription) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, string, *operatorsv1alpha1.Subscription) error); ok {
 		r1 = rf(ctx, namespace, subscription)
 	} else {
 		r1 = ret.Error(1)
@@ -200,27 +218,27 @@ func (_m *MockKubeClientConnector) CreateSubscription(ctx context.Context, names
 }
 
 // CreateSubscriptionForCatalog provides a mock function with given fields: ctx, namespace, name, catalogNamespace, catalog, packageName, channel, startingCSV, approval
-func (_m *MockKubeClientConnector) CreateSubscriptionForCatalog(ctx context.Context, namespace string, name string, catalogNamespace string, catalog string, packageName string, channel string, startingCSV string, approval v1alpha1.Approval) (*v1alpha1.Subscription, error) {
+func (_m *MockKubeClientConnector) CreateSubscriptionForCatalog(ctx context.Context, namespace string, name string, catalogNamespace string, catalog string, packageName string, channel string, startingCSV string, approval operatorsv1alpha1.Approval) (*operatorsv1alpha1.Subscription, error) {
 	ret := _m.Called(ctx, namespace, name, catalogNamespace, catalog, packageName, channel, startingCSV, approval)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CreateSubscriptionForCatalog")
 	}
 
-	var r0 *v1alpha1.Subscription
+	var r0 *operatorsv1alpha1.Subscription
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, string, string, string, string, v1alpha1.Approval) (*v1alpha1.Subscription, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, string, string, string, string, operatorsv1alpha1.Approval) (*operatorsv1alpha1.Subscription, error)); ok {
 		return rf(ctx, namespace, name, catalogNamespace, catalog, packageName, channel, startingCSV, approval)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, string, string, string, string, v1alpha1.Approval) *v1alpha1.Subscription); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, string, string, string, string, operatorsv1alpha1.Approval) *operatorsv1alpha1.Subscription); ok {
 		r0 = rf(ctx, namespace, name, catalogNamespace, catalog, packageName, channel, startingCSV, approval)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*v1alpha1.Subscription)
+			r0 = ret.Get(0).(*operatorsv1alpha1.Subscription)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, string, string, string, string, string, string, v1alpha1.Approval) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, string, string, string, string, string, operatorsv1alpha1.Approval) error); ok {
 		r1 = rf(ctx, namespace, name, catalogNamespace, catalog, packageName, channel, startingCSV, approval)
 	} else {
 		r1 = ret.Error(1)
@@ -240,6 +258,24 @@ func (_m *MockKubeClientConnector) DeleteAllMonitoringResources(ctx context.Cont
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
 		r0 = rf(ctx, namespace)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// DeleteBackupStorage provides a mock function with given fields: ctx, name
+func (_m *MockKubeClientConnector) DeleteBackupStorage(ctx context.Context, name string) error {
+	ret := _m.Called(ctx, name)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteBackupStorage")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = rf(ctx, name)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -403,6 +439,36 @@ func (_m *MockKubeClientConnector) GenerateKubeConfigWithToken(user string, secr
 	return r0, r1
 }
 
+// GetBackupStorage provides a mock function with given fields: ctx, name
+func (_m *MockKubeClientConnector) GetBackupStorage(ctx context.Context, name string) (*v1alpha1.BackupStorage, error) {
+	ret := _m.Called(ctx, name)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetBackupStorage")
+	}
+
+	var r0 *v1alpha1.BackupStorage
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) (*v1alpha1.BackupStorage, error)); ok {
+		return rf(ctx, name)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string) *v1alpha1.BackupStorage); ok {
+		r0 = rf(ctx, name)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*v1alpha1.BackupStorage)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, name)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetClusterRoleBinding provides a mock function with given fields: ctx, name
 func (_m *MockKubeClientConnector) GetClusterRoleBinding(ctx context.Context, name string) (*rbacv1.ClusterRoleBinding, error) {
 	ret := _m.Called(ctx, name)
@@ -434,23 +500,23 @@ func (_m *MockKubeClientConnector) GetClusterRoleBinding(ctx context.Context, na
 }
 
 // GetClusterServiceVersion provides a mock function with given fields: ctx, key
-func (_m *MockKubeClientConnector) GetClusterServiceVersion(ctx context.Context, key types.NamespacedName) (*v1alpha1.ClusterServiceVersion, error) {
+func (_m *MockKubeClientConnector) GetClusterServiceVersion(ctx context.Context, key types.NamespacedName) (*operatorsv1alpha1.ClusterServiceVersion, error) {
 	ret := _m.Called(ctx, key)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetClusterServiceVersion")
 	}
 
-	var r0 *v1alpha1.ClusterServiceVersion
+	var r0 *operatorsv1alpha1.ClusterServiceVersion
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, types.NamespacedName) (*v1alpha1.ClusterServiceVersion, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, types.NamespacedName) (*operatorsv1alpha1.ClusterServiceVersion, error)); ok {
 		return rf(ctx, key)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, types.NamespacedName) *v1alpha1.ClusterServiceVersion); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, types.NamespacedName) *operatorsv1alpha1.ClusterServiceVersion); ok {
 		r0 = rf(ctx, key)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*v1alpha1.ClusterServiceVersion)
+			r0 = ret.Get(0).(*operatorsv1alpha1.ClusterServiceVersion)
 		}
 	}
 
@@ -463,29 +529,119 @@ func (_m *MockKubeClientConnector) GetClusterServiceVersion(ctx context.Context,
 	return r0, r1
 }
 
-// GetDatabaseCluster provides a mock function with given fields: ctx, name
-func (_m *MockKubeClientConnector) GetDatabaseCluster(ctx context.Context, name string) (*apiv1alpha1.DatabaseCluster, error) {
-	ret := _m.Called(ctx, name)
+// GetDatabaseCluster provides a mock function with given fields: ctx, namespace, name
+func (_m *MockKubeClientConnector) GetDatabaseCluster(ctx context.Context, namespace string, name string) (*v1alpha1.DatabaseCluster, error) {
+	ret := _m.Called(ctx, namespace, name)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetDatabaseCluster")
 	}
 
-	var r0 *apiv1alpha1.DatabaseCluster
+	var r0 *v1alpha1.DatabaseCluster
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string) (*apiv1alpha1.DatabaseCluster, error)); ok {
-		return rf(ctx, name)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) (*v1alpha1.DatabaseCluster, error)); ok {
+		return rf(ctx, namespace, name)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string) *apiv1alpha1.DatabaseCluster); ok {
-		r0 = rf(ctx, name)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) *v1alpha1.DatabaseCluster); ok {
+		r0 = rf(ctx, namespace, name)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*apiv1alpha1.DatabaseCluster)
+			r0 = ret.Get(0).(*v1alpha1.DatabaseCluster)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
-		r1 = rf(ctx, name)
+	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = rf(ctx, namespace, name)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GetDatabaseClusterBackup provides a mock function with given fields: ctx, namespace, name
+func (_m *MockKubeClientConnector) GetDatabaseClusterBackup(ctx context.Context, namespace string, name string) (*v1alpha1.DatabaseClusterBackup, error) {
+	ret := _m.Called(ctx, namespace, name)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetDatabaseClusterBackup")
+	}
+
+	var r0 *v1alpha1.DatabaseClusterBackup
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) (*v1alpha1.DatabaseClusterBackup, error)); ok {
+		return rf(ctx, namespace, name)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) *v1alpha1.DatabaseClusterBackup); ok {
+		r0 = rf(ctx, namespace, name)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*v1alpha1.DatabaseClusterBackup)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = rf(ctx, namespace, name)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GetDatabaseClusterRestore provides a mock function with given fields: ctx, namespace, name
+func (_m *MockKubeClientConnector) GetDatabaseClusterRestore(ctx context.Context, namespace string, name string) (*v1alpha1.DatabaseClusterRestore, error) {
+	ret := _m.Called(ctx, namespace, name)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetDatabaseClusterRestore")
+	}
+
+	var r0 *v1alpha1.DatabaseClusterRestore
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) (*v1alpha1.DatabaseClusterRestore, error)); ok {
+		return rf(ctx, namespace, name)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) *v1alpha1.DatabaseClusterRestore); ok {
+		r0 = rf(ctx, namespace, name)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*v1alpha1.DatabaseClusterRestore)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = rf(ctx, namespace, name)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GetDatabaseEngine provides a mock function with given fields: ctx, namespace, name
+func (_m *MockKubeClientConnector) GetDatabaseEngine(ctx context.Context, namespace string, name string) (*v1alpha1.DatabaseEngine, error) {
+	ret := _m.Called(ctx, namespace, name)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetDatabaseEngine")
+	}
+
+	var r0 *v1alpha1.DatabaseEngine
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) (*v1alpha1.DatabaseEngine, error)); ok {
+		return rf(ctx, namespace, name)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) *v1alpha1.DatabaseEngine); ok {
+		r0 = rf(ctx, namespace, name)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*v1alpha1.DatabaseEngine)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = rf(ctx, namespace, name)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -552,23 +708,23 @@ func (_m *MockKubeClientConnector) GetEvents(ctx context.Context, name string) (
 }
 
 // GetInstallPlan provides a mock function with given fields: ctx, namespace, name
-func (_m *MockKubeClientConnector) GetInstallPlan(ctx context.Context, namespace string, name string) (*v1alpha1.InstallPlan, error) {
+func (_m *MockKubeClientConnector) GetInstallPlan(ctx context.Context, namespace string, name string) (*operatorsv1alpha1.InstallPlan, error) {
 	ret := _m.Called(ctx, namespace, name)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetInstallPlan")
 	}
 
-	var r0 *v1alpha1.InstallPlan
+	var r0 *operatorsv1alpha1.InstallPlan
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) (*v1alpha1.InstallPlan, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) (*operatorsv1alpha1.InstallPlan, error)); ok {
 		return rf(ctx, namespace, name)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) *v1alpha1.InstallPlan); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) *operatorsv1alpha1.InstallPlan); ok {
 		r0 = rf(ctx, namespace, name)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*v1alpha1.InstallPlan)
+			r0 = ret.Get(0).(*operatorsv1alpha1.InstallPlan)
 		}
 	}
 
@@ -940,23 +1096,23 @@ func (_m *MockKubeClientConnector) GetStorageClasses(ctx context.Context) (*stor
 }
 
 // GetSubscription provides a mock function with given fields: ctx, namespace, name
-func (_m *MockKubeClientConnector) GetSubscription(ctx context.Context, namespace string, name string) (*v1alpha1.Subscription, error) {
+func (_m *MockKubeClientConnector) GetSubscription(ctx context.Context, namespace string, name string) (*operatorsv1alpha1.Subscription, error) {
 	ret := _m.Called(ctx, namespace, name)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetSubscription")
 	}
 
-	var r0 *v1alpha1.Subscription
+	var r0 *operatorsv1alpha1.Subscription
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) (*v1alpha1.Subscription, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) (*operatorsv1alpha1.Subscription, error)); ok {
 		return rf(ctx, namespace, name)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) *v1alpha1.Subscription); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) *operatorsv1alpha1.Subscription); ok {
 		r0 = rf(ctx, namespace, name)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*v1alpha1.Subscription)
+			r0 = ret.Get(0).(*operatorsv1alpha1.Subscription)
 		}
 	}
 
@@ -990,6 +1146,36 @@ func (_m *MockKubeClientConnector) GetSubscriptionCSV(ctx context.Context, subKe
 
 	if rf, ok := ret.Get(1).(func(context.Context, types.NamespacedName) error); ok {
 		r1 = rf(ctx, subKey)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// ListBackupStorages provides a mock function with given fields: ctx, options
+func (_m *MockKubeClientConnector) ListBackupStorages(ctx context.Context, options metav1.ListOptions) (*v1alpha1.BackupStorageList, error) {
+	ret := _m.Called(ctx, options)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListBackupStorages")
+	}
+
+	var r0 *v1alpha1.BackupStorageList
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, metav1.ListOptions) (*v1alpha1.BackupStorageList, error)); ok {
+		return rf(ctx, options)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, metav1.ListOptions) *v1alpha1.BackupStorageList); ok {
+		r0 = rf(ctx, options)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*v1alpha1.BackupStorageList)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, metav1.ListOptions) error); ok {
+		r1 = rf(ctx, options)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1058,23 +1244,23 @@ func (_m *MockKubeClientConnector) ListCRs(ctx context.Context, namespace string
 }
 
 // ListClusterServiceVersion provides a mock function with given fields: ctx, namespace
-func (_m *MockKubeClientConnector) ListClusterServiceVersion(ctx context.Context, namespace string) (*v1alpha1.ClusterServiceVersionList, error) {
+func (_m *MockKubeClientConnector) ListClusterServiceVersion(ctx context.Context, namespace string) (*operatorsv1alpha1.ClusterServiceVersionList, error) {
 	ret := _m.Called(ctx, namespace)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ListClusterServiceVersion")
 	}
 
-	var r0 *v1alpha1.ClusterServiceVersionList
+	var r0 *operatorsv1alpha1.ClusterServiceVersionList
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string) (*v1alpha1.ClusterServiceVersionList, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string) (*operatorsv1alpha1.ClusterServiceVersionList, error)); ok {
 		return rf(ctx, namespace)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string) *v1alpha1.ClusterServiceVersionList); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string) *operatorsv1alpha1.ClusterServiceVersionList); ok {
 		r0 = rf(ctx, namespace)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*v1alpha1.ClusterServiceVersionList)
+			r0 = ret.Get(0).(*operatorsv1alpha1.ClusterServiceVersionList)
 		}
 	}
 
@@ -1087,29 +1273,119 @@ func (_m *MockKubeClientConnector) ListClusterServiceVersion(ctx context.Context
 	return r0, r1
 }
 
-// ListDatabaseClusters provides a mock function with given fields: ctx
-func (_m *MockKubeClientConnector) ListDatabaseClusters(ctx context.Context) (*apiv1alpha1.DatabaseClusterList, error) {
-	ret := _m.Called(ctx)
+// ListDatabaseClusterBackups provides a mock function with given fields: ctx, namespace, options
+func (_m *MockKubeClientConnector) ListDatabaseClusterBackups(ctx context.Context, namespace string, options metav1.ListOptions) (*v1alpha1.DatabaseClusterBackupList, error) {
+	ret := _m.Called(ctx, namespace, options)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListDatabaseClusterBackups")
+	}
+
+	var r0 *v1alpha1.DatabaseClusterBackupList
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, metav1.ListOptions) (*v1alpha1.DatabaseClusterBackupList, error)); ok {
+		return rf(ctx, namespace, options)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, metav1.ListOptions) *v1alpha1.DatabaseClusterBackupList); ok {
+		r0 = rf(ctx, namespace, options)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*v1alpha1.DatabaseClusterBackupList)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, metav1.ListOptions) error); ok {
+		r1 = rf(ctx, namespace, options)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// ListDatabaseClusterRestores provides a mock function with given fields: ctx, namespace, options
+func (_m *MockKubeClientConnector) ListDatabaseClusterRestores(ctx context.Context, namespace string, options metav1.ListOptions) (*v1alpha1.DatabaseClusterRestoreList, error) {
+	ret := _m.Called(ctx, namespace, options)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListDatabaseClusterRestores")
+	}
+
+	var r0 *v1alpha1.DatabaseClusterRestoreList
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, metav1.ListOptions) (*v1alpha1.DatabaseClusterRestoreList, error)); ok {
+		return rf(ctx, namespace, options)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, metav1.ListOptions) *v1alpha1.DatabaseClusterRestoreList); ok {
+		r0 = rf(ctx, namespace, options)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*v1alpha1.DatabaseClusterRestoreList)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, metav1.ListOptions) error); ok {
+		r1 = rf(ctx, namespace, options)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// ListDatabaseClusters provides a mock function with given fields: ctx, namespace, options
+func (_m *MockKubeClientConnector) ListDatabaseClusters(ctx context.Context, namespace string, options metav1.ListOptions) (*v1alpha1.DatabaseClusterList, error) {
+	ret := _m.Called(ctx, namespace, options)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ListDatabaseClusters")
 	}
 
-	var r0 *apiv1alpha1.DatabaseClusterList
+	var r0 *v1alpha1.DatabaseClusterList
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context) (*apiv1alpha1.DatabaseClusterList, error)); ok {
-		return rf(ctx)
+	if rf, ok := ret.Get(0).(func(context.Context, string, metav1.ListOptions) (*v1alpha1.DatabaseClusterList, error)); ok {
+		return rf(ctx, namespace, options)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context) *apiv1alpha1.DatabaseClusterList); ok {
-		r0 = rf(ctx)
+	if rf, ok := ret.Get(0).(func(context.Context, string, metav1.ListOptions) *v1alpha1.DatabaseClusterList); ok {
+		r0 = rf(ctx, namespace, options)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*apiv1alpha1.DatabaseClusterList)
+			r0 = ret.Get(0).(*v1alpha1.DatabaseClusterList)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
-		r1 = rf(ctx)
+	if rf, ok := ret.Get(1).(func(context.Context, string, metav1.ListOptions) error); ok {
+		r1 = rf(ctx, namespace, options)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// ListDatabaseEngines provides a mock function with given fields: ctx, namespace
+func (_m *MockKubeClientConnector) ListDatabaseEngines(ctx context.Context, namespace string) (*v1alpha1.DatabaseEngineList, error) {
+	ret := _m.Called(ctx, namespace)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListDatabaseEngines")
+	}
+
+	var r0 *v1alpha1.DatabaseEngineList
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) (*v1alpha1.DatabaseEngineList, error)); ok {
+		return rf(ctx, namespace)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string) *v1alpha1.DatabaseEngineList); ok {
+		r0 = rf(ctx, namespace)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*v1alpha1.DatabaseEngineList)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, namespace)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1208,23 +1484,23 @@ func (_m *MockKubeClientConnector) ListSecrets(ctx context.Context) (*corev1.Sec
 }
 
 // ListSubscriptions provides a mock function with given fields: ctx, namespace
-func (_m *MockKubeClientConnector) ListSubscriptions(ctx context.Context, namespace string) (*v1alpha1.SubscriptionList, error) {
+func (_m *MockKubeClientConnector) ListSubscriptions(ctx context.Context, namespace string) (*operatorsv1alpha1.SubscriptionList, error) {
 	ret := _m.Called(ctx, namespace)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ListSubscriptions")
 	}
 
-	var r0 *v1alpha1.SubscriptionList
+	var r0 *operatorsv1alpha1.SubscriptionList
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string) (*v1alpha1.SubscriptionList, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string) (*operatorsv1alpha1.SubscriptionList, error)); ok {
 		return rf(ctx, namespace)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string) *v1alpha1.SubscriptionList); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string) *operatorsv1alpha1.SubscriptionList); ok {
 		r0 = rf(ctx, namespace)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*v1alpha1.SubscriptionList)
+			r0 = ret.Get(0).(*operatorsv1alpha1.SubscriptionList)
 		}
 	}
 
@@ -1237,28 +1513,46 @@ func (_m *MockKubeClientConnector) ListSubscriptions(ctx context.Context, namesp
 	return r0, r1
 }
 
+// UpdateBackupStorage provides a mock function with given fields: ctx, storage
+func (_m *MockKubeClientConnector) UpdateBackupStorage(ctx context.Context, storage *v1alpha1.BackupStorage) error {
+	ret := _m.Called(ctx, storage)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateBackupStorage")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, *v1alpha1.BackupStorage) error); ok {
+		r0 = rf(ctx, storage)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // UpdateInstallPlan provides a mock function with given fields: ctx, namespace, installPlan
-func (_m *MockKubeClientConnector) UpdateInstallPlan(ctx context.Context, namespace string, installPlan *v1alpha1.InstallPlan) (*v1alpha1.InstallPlan, error) {
+func (_m *MockKubeClientConnector) UpdateInstallPlan(ctx context.Context, namespace string, installPlan *operatorsv1alpha1.InstallPlan) (*operatorsv1alpha1.InstallPlan, error) {
 	ret := _m.Called(ctx, namespace, installPlan)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpdateInstallPlan")
 	}
 
-	var r0 *v1alpha1.InstallPlan
+	var r0 *operatorsv1alpha1.InstallPlan
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, *v1alpha1.InstallPlan) (*v1alpha1.InstallPlan, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string, *operatorsv1alpha1.InstallPlan) (*operatorsv1alpha1.InstallPlan, error)); ok {
 		return rf(ctx, namespace, installPlan)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, *v1alpha1.InstallPlan) *v1alpha1.InstallPlan); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string, *operatorsv1alpha1.InstallPlan) *operatorsv1alpha1.InstallPlan); ok {
 		r0 = rf(ctx, namespace, installPlan)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*v1alpha1.InstallPlan)
+			r0 = ret.Get(0).(*operatorsv1alpha1.InstallPlan)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, *v1alpha1.InstallPlan) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, string, *operatorsv1alpha1.InstallPlan) error); ok {
 		r1 = rf(ctx, namespace, installPlan)
 	} else {
 		r1 = ret.Error(1)
@@ -1268,27 +1562,27 @@ func (_m *MockKubeClientConnector) UpdateInstallPlan(ctx context.Context, namesp
 }
 
 // UpdateSubscription provides a mock function with given fields: ctx, namespace, subscription
-func (_m *MockKubeClientConnector) UpdateSubscription(ctx context.Context, namespace string, subscription *v1alpha1.Subscription) (*v1alpha1.Subscription, error) {
+func (_m *MockKubeClientConnector) UpdateSubscription(ctx context.Context, namespace string, subscription *operatorsv1alpha1.Subscription) (*operatorsv1alpha1.Subscription, error) {
 	ret := _m.Called(ctx, namespace, subscription)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpdateSubscription")
 	}
 
-	var r0 *v1alpha1.Subscription
+	var r0 *operatorsv1alpha1.Subscription
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, *v1alpha1.Subscription) (*v1alpha1.Subscription, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string, *operatorsv1alpha1.Subscription) (*operatorsv1alpha1.Subscription, error)); ok {
 		return rf(ctx, namespace, subscription)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, *v1alpha1.Subscription) *v1alpha1.Subscription); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string, *operatorsv1alpha1.Subscription) *operatorsv1alpha1.Subscription); ok {
 		r0 = rf(ctx, namespace, subscription)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*v1alpha1.Subscription)
+			r0 = ret.Get(0).(*operatorsv1alpha1.Subscription)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, *v1alpha1.Subscription) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, string, *operatorsv1alpha1.Subscription) error); ok {
 		r1 = rf(ctx, namespace, subscription)
 	} else {
 		r1 = ret.Error(1)

--- a/pkg/kubernetes/client/mock_kube_client_connector.go
+++ b/pkg/kubernetes/client/mock_kube_client_connector.go
@@ -301,6 +301,24 @@ func (_m *MockKubeClientConnector) DeleteBackupStorage(ctx context.Context, name
 	return r0
 }
 
+// DeleteClusterServiceVersion provides a mock function with given fields: ctx, key
+func (_m *MockKubeClientConnector) DeleteClusterServiceVersion(ctx context.Context, key types.NamespacedName) error {
+	ret := _m.Called(ctx, key)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteClusterServiceVersion")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, types.NamespacedName) error); ok {
+		r0 = rf(ctx, key)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // DeleteFile provides a mock function with given fields: fileBytes
 func (_m *MockKubeClientConnector) DeleteFile(fileBytes []byte) error {
 	ret := _m.Called(fileBytes)

--- a/pkg/kubernetes/client/mock_kube_client_connector.go
+++ b/pkg/kubernetes/client/mock_kube_client_connector.go
@@ -139,6 +139,24 @@ func (_m *MockKubeClientConnector) CreateBackupStorage(ctx context.Context, stor
 	return r0
 }
 
+// CreateMonitoringConfig provides a mock function with given fields: ctx, config
+func (_m *MockKubeClientConnector) CreateMonitoringConfig(ctx context.Context, config *v1alpha1.MonitoringConfig) error {
+	ret := _m.Called(ctx, config)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateMonitoringConfig")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, *v1alpha1.MonitoringConfig) error); ok {
+		r0 = rf(ctx, config)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // CreateNamespace provides a mock function with given fields: name
 func (_m *MockKubeClientConnector) CreateNamespace(name string) error {
 	ret := _m.Called(name)
@@ -312,6 +330,24 @@ func (_m *MockKubeClientConnector) DeleteManifestFile(fileBytes []byte, namespac
 	var r0 error
 	if rf, ok := ret.Get(0).(func([]byte, string) error); ok {
 		r0 = rf(fileBytes, namespace)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// DeleteMonitoringConfig provides a mock function with given fields: ctx, namespace, name
+func (_m *MockKubeClientConnector) DeleteMonitoringConfig(ctx context.Context, namespace string, name string) error {
+	ret := _m.Called(ctx, namespace, name)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteMonitoringConfig")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
+		r0 = rf(ctx, namespace, name)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -776,6 +812,36 @@ func (_m *MockKubeClientConnector) GetLogs(ctx context.Context, pod string, cont
 
 	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
 		r1 = rf(ctx, pod, container)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GetMonitoringConfig provides a mock function with given fields: ctx, namespace, name
+func (_m *MockKubeClientConnector) GetMonitoringConfig(ctx context.Context, namespace string, name string) (*v1alpha1.MonitoringConfig, error) {
+	ret := _m.Called(ctx, namespace, name)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetMonitoringConfig")
+	}
+
+	var r0 *v1alpha1.MonitoringConfig
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) (*v1alpha1.MonitoringConfig, error)); ok {
+		return rf(ctx, namespace, name)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) *v1alpha1.MonitoringConfig); ok {
+		r0 = rf(ctx, namespace, name)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*v1alpha1.MonitoringConfig)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = rf(ctx, namespace, name)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1441,6 +1507,36 @@ func (_m *MockKubeClientConnector) ListDeployments(ctx context.Context, namespac
 	return r0, r1
 }
 
+// ListMonitoringConfigs provides a mock function with given fields: ctx, namespace
+func (_m *MockKubeClientConnector) ListMonitoringConfigs(ctx context.Context, namespace string) (*v1alpha1.MonitoringConfigList, error) {
+	ret := _m.Called(ctx, namespace)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListMonitoringConfigs")
+	}
+
+	var r0 *v1alpha1.MonitoringConfigList
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) (*v1alpha1.MonitoringConfigList, error)); ok {
+		return rf(ctx, namespace)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string) *v1alpha1.MonitoringConfigList); ok {
+		r0 = rf(ctx, namespace)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*v1alpha1.MonitoringConfigList)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, namespace)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // ListPods provides a mock function with given fields: ctx, namespace, options
 func (_m *MockKubeClientConnector) ListPods(ctx context.Context, namespace string, options metav1.ListOptions) (*corev1.PodList, error) {
 	ret := _m.Called(ctx, namespace, options)
@@ -1577,6 +1673,24 @@ func (_m *MockKubeClientConnector) UpdateInstallPlan(ctx context.Context, namesp
 	}
 
 	return r0, r1
+}
+
+// UpdateMonitoringConfig provides a mock function with given fields: ctx, config
+func (_m *MockKubeClientConnector) UpdateMonitoringConfig(ctx context.Context, config *v1alpha1.MonitoringConfig) error {
+	ret := _m.Called(ctx, config)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateMonitoringConfig")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, *v1alpha1.MonitoringConfig) error); ok {
+		r0 = rf(ctx, config)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
 }
 
 // UpdateSubscription provides a mock function with given fields: ctx, namespace, subscription

--- a/pkg/kubernetes/client/mock_kube_client_connector.go
+++ b/pkg/kubernetes/client/mock_kube_client_connector.go
@@ -265,17 +265,17 @@ func (_m *MockKubeClientConnector) DeleteAllMonitoringResources(ctx context.Cont
 	return r0
 }
 
-// DeleteBackupStorage provides a mock function with given fields: ctx, name
-func (_m *MockKubeClientConnector) DeleteBackupStorage(ctx context.Context, name string) error {
-	ret := _m.Called(ctx, name)
+// DeleteBackupStorage provides a mock function with given fields: ctx, namespace, name
+func (_m *MockKubeClientConnector) DeleteBackupStorage(ctx context.Context, namespace string, name string) error {
+	ret := _m.Called(ctx, namespace, name)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteBackupStorage")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
-		r0 = rf(ctx, name)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
+		r0 = rf(ctx, namespace, name)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -457,9 +457,9 @@ func (_m *MockKubeClientConnector) GenerateKubeConfigWithToken(user string, secr
 	return r0, r1
 }
 
-// GetBackupStorage provides a mock function with given fields: ctx, name
-func (_m *MockKubeClientConnector) GetBackupStorage(ctx context.Context, name string) (*v1alpha1.BackupStorage, error) {
-	ret := _m.Called(ctx, name)
+// GetBackupStorage provides a mock function with given fields: ctx, namespace, name
+func (_m *MockKubeClientConnector) GetBackupStorage(ctx context.Context, namespace string, name string) (*v1alpha1.BackupStorage, error) {
+	ret := _m.Called(ctx, namespace, name)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetBackupStorage")
@@ -467,19 +467,19 @@ func (_m *MockKubeClientConnector) GetBackupStorage(ctx context.Context, name st
 
 	var r0 *v1alpha1.BackupStorage
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string) (*v1alpha1.BackupStorage, error)); ok {
-		return rf(ctx, name)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) (*v1alpha1.BackupStorage, error)); ok {
+		return rf(ctx, namespace, name)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string) *v1alpha1.BackupStorage); ok {
-		r0 = rf(ctx, name)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) *v1alpha1.BackupStorage); ok {
+		r0 = rf(ctx, namespace, name)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*v1alpha1.BackupStorage)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
-		r1 = rf(ctx, name)
+	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = rf(ctx, namespace, name)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1171,9 +1171,9 @@ func (_m *MockKubeClientConnector) GetSubscriptionCSV(ctx context.Context, subKe
 	return r0, r1
 }
 
-// ListBackupStorages provides a mock function with given fields: ctx, options
-func (_m *MockKubeClientConnector) ListBackupStorages(ctx context.Context, options metav1.ListOptions) (*v1alpha1.BackupStorageList, error) {
-	ret := _m.Called(ctx, options)
+// ListBackupStorages provides a mock function with given fields: ctx, namespace, options
+func (_m *MockKubeClientConnector) ListBackupStorages(ctx context.Context, namespace string, options metav1.ListOptions) (*v1alpha1.BackupStorageList, error) {
+	ret := _m.Called(ctx, namespace, options)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ListBackupStorages")
@@ -1181,19 +1181,19 @@ func (_m *MockKubeClientConnector) ListBackupStorages(ctx context.Context, optio
 
 	var r0 *v1alpha1.BackupStorageList
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, metav1.ListOptions) (*v1alpha1.BackupStorageList, error)); ok {
-		return rf(ctx, options)
+	if rf, ok := ret.Get(0).(func(context.Context, string, metav1.ListOptions) (*v1alpha1.BackupStorageList, error)); ok {
+		return rf(ctx, namespace, options)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, metav1.ListOptions) *v1alpha1.BackupStorageList); ok {
-		r0 = rf(ctx, options)
+	if rf, ok := ret.Get(0).(func(context.Context, string, metav1.ListOptions) *v1alpha1.BackupStorageList); ok {
+		r0 = rf(ctx, namespace, options)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*v1alpha1.BackupStorageList)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, metav1.ListOptions) error); ok {
-		r1 = rf(ctx, options)
+	if rf, ok := ret.Get(1).(func(context.Context, string, metav1.ListOptions) error); ok {
+		r1 = rf(ctx, namespace, options)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/kubernetes/client/monitoring_config.go
+++ b/pkg/kubernetes/client/monitoring_config.go
@@ -1,0 +1,51 @@
+// everest
+// Copyright (C) 2023 Percona LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package client ...
+package client
+
+import (
+	"context"
+
+	everestv1alpha1 "github.com/percona/everest-operator/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// CreateMonitoringConfig creates an monitoringConfig.
+func (c *Client) CreateMonitoringConfig(ctx context.Context, config *everestv1alpha1.MonitoringConfig) error {
+	_, err := c.customClientSet.MonitoringConfig(config.Namespace).Create(ctx, config, metav1.CreateOptions{})
+	return err
+}
+
+// UpdateMonitoringConfig updates an monitoringConfig.
+func (c *Client) UpdateMonitoringConfig(ctx context.Context, config *everestv1alpha1.MonitoringConfig) error {
+	_, err := c.customClientSet.MonitoringConfig(config.Namespace).Update(ctx, config, metav1.UpdateOptions{})
+	return err
+}
+
+// GetMonitoringConfig returns the monitoringConfig.
+func (c *Client) GetMonitoringConfig(ctx context.Context, namespace, name string) (*everestv1alpha1.MonitoringConfig, error) {
+	return c.customClientSet.MonitoringConfig(namespace).Get(ctx, name, metav1.GetOptions{})
+}
+
+// ListMonitoringConfigs returns the monitoringConfig.
+func (c *Client) ListMonitoringConfigs(ctx context.Context, namespace string) (*everestv1alpha1.MonitoringConfigList, error) {
+	return c.customClientSet.MonitoringConfig(namespace).List(ctx, metav1.ListOptions{})
+}
+
+// DeleteMonitoringConfig deletes the monitoringConfig.
+func (c *Client) DeleteMonitoringConfig(ctx context.Context, namespace, name string) error {
+	return c.customClientSet.MonitoringConfig(namespace).Delete(ctx, name, metav1.DeleteOptions{})
+}

--- a/pkg/kubernetes/client/namespace.go
+++ b/pkg/kubernetes/client/namespace.go
@@ -11,3 +11,8 @@ import (
 func (c *Client) GetNamespace(ctx context.Context, name string) (*corev1.Namespace, error) {
 	return c.clientset.CoreV1().Namespaces().Get(ctx, name, metav1.GetOptions{})
 }
+
+// DeleteNamespace deletes a namespace.
+func (c *Client) DeleteNamespace(ctx context.Context, name string) error {
+	return c.clientset.CoreV1().Namespaces().Delete(ctx, name, metav1.DeleteOptions{})
+}

--- a/pkg/kubernetes/database_cluster.go
+++ b/pkg/kubernetes/database_cluster.go
@@ -1,0 +1,59 @@
+// everest
+// Copyright (C) 2023 Percona LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package kubernetes ...
+package kubernetes
+
+import (
+	"context"
+
+	everestv1alpha1 "github.com/percona/everest-operator/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ListDatabaseClusters returns list of managed database clusters.
+func (k *Kubernetes) ListDatabaseClusters(ctx context.Context, namespace string) (*everestv1alpha1.DatabaseClusterList, error) {
+	return k.client.ListDatabaseClusters(ctx, namespace, metav1.ListOptions{})
+}
+
+// GetDatabaseCluster returns database clusters by provided name.
+func (k *Kubernetes) GetDatabaseCluster(ctx context.Context, namespace, name string) (*everestv1alpha1.DatabaseCluster, error) {
+	return k.client.GetDatabaseCluster(ctx, namespace, name)
+}
+
+// CreateDatabaseCluster creates database cluster.
+func (k *Kubernetes) CreateDatabaseCluster(cluster *everestv1alpha1.DatabaseCluster) error {
+	if cluster.ObjectMeta.Annotations == nil {
+		cluster.ObjectMeta.Annotations = make(map[string]string)
+	}
+	cluster.ObjectMeta.Annotations[managedByKey] = "pmm"
+	return k.client.ApplyObject(cluster)
+}
+
+// PatchDatabaseCluster patches CR of managed Database cluster.
+func (k *Kubernetes) PatchDatabaseCluster(cluster *everestv1alpha1.DatabaseCluster) error {
+	return k.client.ApplyObject(cluster)
+}
+
+// DeleteDatabaseCluster deletes database cluster.
+func (k *Kubernetes) DeleteDatabaseCluster(ctx context.Context, namespace, name string) error {
+	cluster, err := k.client.GetDatabaseCluster(ctx, namespace, name)
+	if err != nil {
+		return err
+	}
+	cluster.TypeMeta.APIVersion = databaseClusterAPIVersion
+	cluster.TypeMeta.Kind = databaseClusterKind
+	return k.client.DeleteObject(cluster)
+}

--- a/pkg/kubernetes/database_cluster_backup.go
+++ b/pkg/kubernetes/database_cluster_backup.go
@@ -1,0 +1,33 @@
+// everest
+// Copyright (C) 2023 Percona LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"context"
+
+	everestv1alpha1 "github.com/percona/everest-operator/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// GetDatabaseClusterBackup returns database cluster backup by name.
+func (k *Kubernetes) GetDatabaseClusterBackup(ctx context.Context, namespace, name string) (*everestv1alpha1.DatabaseClusterBackup, error) {
+	return k.client.GetDatabaseClusterBackup(ctx, namespace, name)
+}
+
+// ListDatabaseClusterBackups returns database cluster backups.
+func (k *Kubernetes) ListDatabaseClusterBackups(ctx context.Context, namespace string, options metav1.ListOptions) (*everestv1alpha1.DatabaseClusterBackupList, error) {
+	return k.client.ListDatabaseClusterBackups(ctx, namespace, options)
+}

--- a/pkg/kubernetes/database_cluster_restore.go
+++ b/pkg/kubernetes/database_cluster_restore.go
@@ -1,0 +1,33 @@
+// everest
+// Copyright (C) 2023 Percona LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"context"
+
+	everestv1alpha1 "github.com/percona/everest-operator/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// GetDatabaseClusterRestore returns database cluster restore by name.
+func (k *Kubernetes) GetDatabaseClusterRestore(ctx context.Context, namespace, name string) (*everestv1alpha1.DatabaseClusterRestore, error) {
+	return k.client.GetDatabaseClusterRestore(ctx, namespace, name)
+}
+
+// ListDatabaseClusterRestores returns database cluster restores.
+func (k *Kubernetes) ListDatabaseClusterRestores(ctx context.Context, namespace string, options metav1.ListOptions) (*everestv1alpha1.DatabaseClusterRestoreList, error) {
+	return k.client.ListDatabaseClusterRestores(ctx, namespace, options)
+}

--- a/pkg/kubernetes/database_engine.go
+++ b/pkg/kubernetes/database_engine.go
@@ -1,0 +1,33 @@
+// everest
+// Copyright (C) 2023 Percona LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package kubernetes ...
+package kubernetes
+
+import (
+	"context"
+
+	everestv1alpha1 "github.com/percona/everest-operator/api/v1alpha1"
+)
+
+// ListDatabaseEngines returns list of managed database clusters.
+func (k *Kubernetes) ListDatabaseEngines(ctx context.Context, namespace string) (*everestv1alpha1.DatabaseEngineList, error) {
+	return k.client.ListDatabaseEngines(ctx, namespace)
+}
+
+// GetDatabaseEngine returns database clusters by provided name.
+func (k *Kubernetes) GetDatabaseEngine(ctx context.Context, namespace, name string) (*everestv1alpha1.DatabaseEngine, error) {
+	return k.client.GetDatabaseEngine(ctx, namespace, name)
+}

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -840,6 +840,14 @@ func (k *Kubernetes) ListClusterServiceVersion(
 	return k.client.ListClusterServiceVersion(ctx, namespace)
 }
 
+// DeleteClusterServiceVersion deletes a ClusterServiceVersion.
+func (k *Kubernetes) DeleteClusterServiceVersion(
+	ctx context.Context,
+	key types.NamespacedName,
+) error {
+	return k.client.DeleteClusterServiceVersion(ctx, key)
+}
+
 // DeleteObject deletes an object.
 func (k *Kubernetes) DeleteObject(obj runtime.Object) error {
 	return k.client.DeleteObject(obj)

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -470,7 +470,7 @@ func (k *Kubernetes) InstallPerconaCatalog(ctx context.Context) error {
 	if err := k.client.ApplyFile(data); err != nil {
 		return errors.Join(err, errors.New("cannot apply percona catalog file"))
 	}
-	if err := k.client.DoPackageWait(ctx, "everest-operator"); err != nil {
+	if err := k.client.DoPackageWait(ctx, OLMNamespace, "everest-operator"); err != nil {
 		return errors.Join(err, errors.New("timeout waiting for package"))
 	}
 	return nil

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -94,7 +94,8 @@ const (
 	// then either ran to completion or failed for some reason.
 	ContainerStateTerminated ContainerState = "terminated"
 
-	olmNamespace    = "everest-olm"
+	// OLMNamespace is the namespace where OLM is installed.
+	OLMNamespace    = "everest-olm"
 	olmOperatorName = "olm-operator"
 
 	// APIVersionCoreosV1 constant for some API requests.
@@ -396,7 +397,7 @@ func (k *Kubernetes) GetStorageClasses(ctx context.Context) (*storagev1.StorageC
 
 // InstallOLMOperator installs the OLM in the Kubernetes cluster.
 func (k *Kubernetes) InstallOLMOperator(ctx context.Context, upgrade bool) error {
-	deployment, err := k.client.GetDeployment(ctx, olmOperatorName, olmNamespace)
+	deployment, err := k.client.GetDeployment(ctx, olmOperatorName, OLMNamespace)
 	if err == nil && deployment != nil && deployment.ObjectMeta.Name != "" && !upgrade {
 		k.l.Info("OLM operator is already installed")
 		return nil // already installed
@@ -415,7 +416,7 @@ func (k *Kubernetes) InstallOLMOperator(ctx context.Context, upgrade bool) error
 		return err
 	}
 
-	if err := k.client.DoRolloutWait(ctx, types.NamespacedName{Namespace: olmNamespace, Name: "packageserver"}); err != nil {
+	if err := k.client.DoRolloutWait(ctx, types.NamespacedName{Namespace: OLMNamespace, Name: "packageserver"}); err != nil {
 		return errors.Join(err, errors.New("error while waiting for deployment rollout"))
 	}
 
@@ -518,12 +519,12 @@ func (k *Kubernetes) applyResources(ctx context.Context) ([]unstructured.Unstruc
 
 func (k *Kubernetes) waitForDeploymentRollout(ctx context.Context) error {
 	if err := k.client.DoRolloutWait(ctx, types.NamespacedName{
-		Namespace: olmNamespace,
+		Namespace: OLMNamespace,
 		Name:      olmOperatorName,
 	}); err != nil {
 		return errors.Join(err, errors.New("error while waiting for deployment rollout"))
 	}
-	if err := k.client.DoRolloutWait(ctx, types.NamespacedName{Namespace: olmNamespace, Name: "catalog-operator"}); err != nil {
+	if err := k.client.DoRolloutWait(ctx, types.NamespacedName{Namespace: OLMNamespace, Name: "catalog-operator"}); err != nil {
 		return errors.Join(err, errors.New("error while waiting for deployment rollout"))
 	}
 

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -184,56 +184,6 @@ func (k *Kubernetes) ClusterName() string {
 	return k.client.ClusterName()
 }
 
-// ListDatabaseClusters returns list of managed PCX clusters.
-func (k *Kubernetes) ListDatabaseClusters(ctx context.Context) (*everestv1alpha1.DatabaseClusterList, error) {
-	return k.client.ListDatabaseClusters(ctx)
-}
-
-// GetDatabaseCluster returns PXC clusters by provided name.
-func (k *Kubernetes) GetDatabaseCluster(ctx context.Context, name string) (*everestv1alpha1.DatabaseCluster, error) {
-	return k.client.GetDatabaseCluster(ctx, name)
-}
-
-// RestartDatabaseCluster restarts database cluster.
-func (k *Kubernetes) RestartDatabaseCluster(ctx context.Context, name string) error {
-	cluster, err := k.client.GetDatabaseCluster(ctx, name)
-	if err != nil {
-		return err
-	}
-	cluster.TypeMeta.APIVersion = databaseClusterAPIVersion
-	cluster.TypeMeta.Kind = databaseClusterKind
-	if cluster.ObjectMeta.Annotations == nil {
-		cluster.ObjectMeta.Annotations = make(map[string]string)
-	}
-	cluster.ObjectMeta.Annotations[restartAnnotationKey] = "true"
-	return k.client.ApplyObject(cluster)
-}
-
-// PatchDatabaseCluster patches CR of managed Database cluster.
-func (k *Kubernetes) PatchDatabaseCluster(cluster *everestv1alpha1.DatabaseCluster) error {
-	return k.client.ApplyObject(cluster)
-}
-
-// CreateDatabaseCluster creates database cluster.
-func (k *Kubernetes) CreateDatabaseCluster(cluster *everestv1alpha1.DatabaseCluster) error {
-	if cluster.ObjectMeta.Annotations == nil {
-		cluster.ObjectMeta.Annotations = make(map[string]string)
-	}
-	cluster.ObjectMeta.Annotations[managedByKey] = "pmm"
-	return k.client.ApplyObject(cluster)
-}
-
-// DeleteDatabaseCluster deletes database cluster.
-func (k *Kubernetes) DeleteDatabaseCluster(ctx context.Context, name string) error {
-	cluster, err := k.client.GetDatabaseCluster(ctx, name)
-	if err != nil {
-		return err
-	}
-	cluster.TypeMeta.APIVersion = databaseClusterAPIVersion
-	cluster.TypeMeta.Kind = databaseClusterKind
-	return k.client.DeleteObject(cluster)
-}
-
 // GetDefaultStorageClassName returns first storageClassName from kubernetes cluster.
 func (k *Kubernetes) GetDefaultStorageClassName(ctx context.Context) (string, error) {
 	storageClasses, err := k.client.GetStorageClasses(ctx)

--- a/pkg/kubernetes/monitoring_config.go
+++ b/pkg/kubernetes/monitoring_config.go
@@ -1,0 +1,73 @@
+// everest
+// Copyright (C) 2023 Percona LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package kubernetes ...
+package kubernetes
+
+import (
+	"context"
+
+	everestv1alpha1 "github.com/percona/everest-operator/api/v1alpha1"
+)
+
+const (
+	monitoringConfigNameLabel = "monitoringConfigName"
+)
+
+// ListMonitoringConfigs returns list of managed monitoring configs.
+func (k *Kubernetes) ListMonitoringConfigs(ctx context.Context, namespace string) (*everestv1alpha1.MonitoringConfigList, error) {
+	return k.client.ListMonitoringConfigs(ctx, namespace)
+}
+
+// GetMonitoringConfig returns monitoring configs by provided name.
+func (k *Kubernetes) GetMonitoringConfig(ctx context.Context, namespace, name string) (*everestv1alpha1.MonitoringConfig, error) {
+	return k.client.GetMonitoringConfig(ctx, namespace, name)
+}
+
+// CreateMonitoringConfig returns monitoring configs by provided name.
+func (k *Kubernetes) CreateMonitoringConfig(ctx context.Context, storage *everestv1alpha1.MonitoringConfig) error {
+	return k.client.CreateMonitoringConfig(ctx, storage)
+}
+
+// UpdateMonitoringConfig returns monitoring configs by provided name.
+func (k *Kubernetes) UpdateMonitoringConfig(ctx context.Context, storage *everestv1alpha1.MonitoringConfig) error {
+	return k.client.UpdateMonitoringConfig(ctx, storage)
+}
+
+// DeleteMonitoringConfig returns monitoring configs by provided name.
+func (k *Kubernetes) DeleteMonitoringConfig(ctx context.Context, namespace, name string) error {
+	return k.client.DeleteMonitoringConfig(ctx, namespace, name)
+}
+
+// GetMonitoringConfigsBySecretName returns a list of monitoring configs which use
+// the provided secret name.
+func (k *Kubernetes) GetMonitoringConfigsBySecretName(
+	ctx context.Context, namespace, secretName string,
+) ([]*everestv1alpha1.MonitoringConfig, error) {
+	mcs, err := k.client.ListMonitoringConfigs(ctx, namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	res := make([]*everestv1alpha1.MonitoringConfig, 0, 1)
+	for _, mc := range mcs.Items {
+		mc := mc
+		if mc.Spec.CredentialsSecretName == secretName {
+			res = append(res, &mc)
+		}
+	}
+
+	return res, nil
+}

--- a/pkg/kubernetes/monitoring_config.go
+++ b/pkg/kubernetes/monitoring_config.go
@@ -22,10 +22,6 @@ import (
 	everestv1alpha1 "github.com/percona/everest-operator/api/v1alpha1"
 )
 
-const (
-	monitoringConfigNameLabel = "monitoringConfigName"
-)
-
 // ListMonitoringConfigs returns list of managed monitoring configs.
 func (k *Kubernetes) ListMonitoringConfigs(ctx context.Context, namespace string) (*everestv1alpha1.MonitoringConfigList, error) {
 	return k.client.ListMonitoringConfigs(ctx, namespace)

--- a/pkg/kubernetes/namespace.go
+++ b/pkg/kubernetes/namespace.go
@@ -10,3 +10,8 @@ import (
 func (k *Kubernetes) GetNamespace(ctx context.Context, name string) (*corev1.Namespace, error) {
 	return k.client.GetNamespace(ctx, name)
 }
+
+// DeleteNamespace deletes a namespace.
+func (k *Kubernetes) DeleteNamespace(ctx context.Context, name string) error {
+	return k.client.DeleteNamespace(ctx, name)
+}

--- a/pkg/kubernetes/olm_operator_test.go
+++ b/pkg/kubernetes/olm_operator_test.go
@@ -50,7 +50,7 @@ func TestInstallOlmOperator(t *testing.T) {
 		k8sclient.On(
 			"CreateSubscription", mock.Anything, mock.Anything, mock.Anything,
 		).Return(&v1alpha1.Subscription{}, nil)
-		k8sclient.On("GetDeployment", ctx, mock.Anything, "olm").Return(&appsv1.Deployment{}, nil)
+		k8sclient.On("GetDeployment", ctx, mock.Anything, "everest-olm").Return(&appsv1.Deployment{}, nil)
 		k8sclient.On("ApplyFile", mock.Anything).Return(nil)
 		k8sclient.On("DoRolloutWait", ctx, mock.Anything).Return(nil)
 		k8sclient.On("GetSubscriptionCSV", ctx, mock.Anything).Return(types.NamespacedName{}, nil)
@@ -65,7 +65,7 @@ func TestInstallOlmOperator(t *testing.T) {
 		subscriptionNamespace := "default"
 		operatorGroup := "percona-operators-group"
 		catalogSource := "operatorhubio-catalog"
-		catalogSourceNamespace := "olm"
+		catalogSourceNamespace := "everest-olm"
 		operatorName := "percona-server-mongodb-operator"
 		params := InstallOperatorRequest{
 			Namespace:              subscriptionNamespace,

--- a/pkg/uninstall/uninstall.go
+++ b/pkg/uninstall/uninstall.go
@@ -109,12 +109,12 @@ This will uninstall Everest and all its components from the cluster.`
 		}
 	}
 
-	if err := u.deleteDBNamespaces(ctx); err != nil {
+	// BackupStorages have finalizers, so we need to delete them first
+	if err := u.deleteBackupStorages(ctx); err != nil {
 		return err
 	}
 
-	// BackupStorages have finalizers, so we need to delete them first
-	if err := u.deleteBackupStorages(ctx); err != nil {
+	if err := u.deleteDBNamespaces(ctx); err != nil {
 		return err
 	}
 

--- a/pkg/uninstall/uninstall.go
+++ b/pkg/uninstall/uninstall.go
@@ -18,7 +18,6 @@ package uninstall
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -127,6 +126,12 @@ This will uninstall Everest and all its components from the cluster.`
 	// BackupStorages) have already been deleted, so we can delete the
 	// namespace directly
 	if err := u.deleteNamespaces(ctx, []string{install.SystemNamespace}); err != nil {
+		return err
+	}
+
+	// There are no resources with finalizers in the monitoring namespace, so
+	// we can delete it directly
+	if err := u.deleteNamespaces(ctx, []string{kubernetes.OLMNamespace}); err != nil {
 		return err
 	}
 

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -162,7 +162,7 @@ func (u *Upgrade) patchSubscriptions(ctx context.Context) error {
 func (u *Upgrade) upgradeOLM(ctx context.Context) error {
 	csv, err := u.kubeClient.GetClusterServiceVersion(ctx, types.NamespacedName{
 		Name:      "packageserver",
-		Namespace: "olm",
+		Namespace: kubernetes.OLMNamespace,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
**Fix uninstall command**
---
**Problem:**
EVEREST-838

Rename OLM namespace to `everest-olm`
Remove useless `operators` namespace
Uninstall command now deletes everything (if user approves it):
* Delete DBCs (they can have finalizers, should be deleted first)
* Delete BackupStorages (they can have finalizers, should be deleted first)
* Delete DB namespaces
* Delete monitoring namespace
* Delete system namespace
* Delete OLM namespace

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
