### PR TITLE
EVEREST-843 Comma-separated namespaces flag

### DIFF
--- a/cli-tests/Makefile
+++ b/cli-tests/Makefile
@@ -4,7 +4,7 @@ init:               ## Install dependencies
 
 install-operators:  ## Install operators to k8s
 	../bin/everest install \
-		--namespace percona-everest-operators \
+		--namespaces percona-everest-operators \
 		--skip-wizard \
 
 test-cli:           ## Run all tests

--- a/cli-tests/tests/flow/all-operators.spec.ts
+++ b/cli-tests/tests/flow/all-operators.spec.ts
@@ -46,7 +46,7 @@ test.describe('Everest CLI install', async () => {
 
     await test.step('run everest install command', async () => {
       const out = await cli.everestExecSkipWizard(
-        `install --namespace=everest-all`,
+        `install --namespaces=everest-all`,
       );
 
       await out.assertSuccess();
@@ -73,7 +73,7 @@ test.describe('Everest CLI install', async () => {
 
       await out.assertSuccess();
 
-      out = await cli.everestExecSkipWizardWithEnv('upgrade --namespace=everest-all', 'DISABLE_TELEMETRY=true');
+      out = await cli.everestExecSkipWizardWithEnv('upgrade --namespaces=everest-all', 'DISABLE_TELEMETRY=true');
       await out.assertSuccess();
       await out.outErrContainsNormalizedMany([
         'Subscriptions have been patched\t{"component": "upgrade"}',

--- a/cli-tests/tests/flow/mongodb-operator.spec.ts
+++ b/cli-tests/tests/flow/mongodb-operator.spec.ts
@@ -49,7 +49,7 @@ test.describe('Everest CLI install', async () => {
 
     await test.step('run everest install command', async () => {
       const out = await cli.everestExecSkipWizard(
-        `install --operator.mongodb=true --operator.postgresql=false --operator.xtradb-cluster=false --namespace=everest-operators`,
+        `install --operator.mongodb=true --operator.postgresql=false --operator.xtradb-cluster=false --namespaces=everest-operators`,
       );
 
       await out.assertSuccess();

--- a/cli-tests/tests/flow/pg-operator.spec.ts
+++ b/cli-tests/tests/flow/pg-operator.spec.ts
@@ -48,7 +48,7 @@ test.describe('Everest CLI install', async () => {
 
     await test.step('run everest install command', async () => {
       const out = await cli.everestExecSkipWizard(
-        `install --operator.mongodb=false --operator.postgresql=true --operator.xtradb-cluster=false --namespace=everest-operators`,
+        `install --operator.mongodb=false --operator.postgresql=true --operator.xtradb-cluster=false --namespaces=everest-operators`,
       );
 
       await out.assertSuccess();
@@ -68,7 +68,7 @@ test.describe('Everest CLI install', async () => {
       await operator.assertSuccess();
 
       const out = await cli.everestExecSkipWizard(
-        `install --operator.mongodb=false --operator.postgresql=true --operator.xtradb-cluster=true --namespace=everest-operators`,
+        `install --operator.mongodb=false --operator.postgresql=true --operator.xtradb-cluster=true --namespaces=everest-operators`,
       );
       const restartedOperator = await cli.exec(`kubectl -n everest-system get po | grep everest|awk {'print $1'}`);
       await restartedOperator.assertSuccess();

--- a/cli-tests/tests/flow/pxc-operator.spec.ts
+++ b/cli-tests/tests/flow/pxc-operator.spec.ts
@@ -49,7 +49,7 @@ test.describe('Everest CLI install', async () => {
 
     await test.step('run everest install command', async () => {
       const out = await cli.everestExecSkipWizard(
-        `install --operator.mongodb=false --operator.postgresql=false --operator.xtradb-cluster=true --namespace=everest-operators`,
+        `install --operator.mongodb=false --operator.postgresql=false --operator.xtradb-cluster=true --namespaces=everest-operators`,
       );
 
       await out.assertSuccess();

--- a/commands/install.go
+++ b/commands/install.go
@@ -30,7 +30,7 @@ import (
 func newInstallCmd(l *zap.SugaredLogger) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "install",
-		Example: "everestctl install --namespace dev --namespace staging --namespace prod --operator.mongodb=true --operator.postgresql=true --operator.xtradb-cluster=true --skip-wizard",
+		Example: "everestctl install --namespaces dev,staging,prod --operator.mongodb=true --operator.postgresql=true --operator.xtradb-cluster=true --skip-wizard",
 		Run: func(cmd *cobra.Command, args []string) {
 			initInstallViperFlags(cmd)
 			c := &install.Config{}
@@ -58,7 +58,7 @@ func newInstallCmd(l *zap.SugaredLogger) *cobra.Command {
 
 func initInstallFlags(cmd *cobra.Command) {
 	cmd.Flags().StringP("kubeconfig", "k", "~/.kube/config", "Path to a kubeconfig")
-	cmd.Flags().StringArray("namespace", []string{}, "Namespaces list Percona Everest can manage")
+	cmd.Flags().String("namespaces", "", "Comma-separated namespaces list Percona Everest can manage")
 	cmd.Flags().Bool("skip-wizard", false, "Skip installation wizard")
 
 	cmd.Flags().Bool("operator.mongodb", true, "Install MongoDB operator")
@@ -71,7 +71,7 @@ func initInstallViperFlags(cmd *cobra.Command) {
 
 	viper.BindEnv("kubeconfig")                                     //nolint:errcheck,gosec
 	viper.BindPFlag("kubeconfig", cmd.Flags().Lookup("kubeconfig")) //nolint:errcheck,gosec
-	viper.BindPFlag("namespace", cmd.Flags().Lookup("namespace"))   //nolint:errcheck,gosec
+	viper.BindPFlag("namespaces", cmd.Flags().Lookup("namespaces")) //nolint:errcheck,gosec
 
 	viper.BindPFlag("operator.mongodb", cmd.Flags().Lookup("operator.mongodb"))               //nolint:errcheck,gosec
 	viper.BindPFlag("operator.postgresql", cmd.Flags().Lookup("operator.postgresql"))         //nolint:errcheck,gosec

--- a/commands/upgrade.go
+++ b/commands/upgrade.go
@@ -59,7 +59,7 @@ func newUpgradeCmd(l *zap.SugaredLogger) *cobra.Command {
 
 func initUpgradeFlags(cmd *cobra.Command) {
 	cmd.Flags().StringP("kubeconfig", "k", "~/.kube/config", "Path to a kubeconfig")
-	cmd.Flags().StringArray("namespace", []string{}, "Namespaces list Percona Everest can manage")
+	cmd.Flags().String("namespaces", "", "Comma-separated namespaces list Percona Everest can manage")
 	cmd.Flags().Bool("upgrade-olm", false, "Upgrade OLM distribution")
 	cmd.Flags().Bool("skip-wizard", false, "Skip installation wizard")
 }
@@ -67,7 +67,7 @@ func initUpgradeFlags(cmd *cobra.Command) {
 func initUpgradeViperFlags(cmd *cobra.Command) {
 	viper.BindEnv("kubeconfig")                                       //nolint:errcheck,gosec
 	viper.BindPFlag("kubeconfig", cmd.Flags().Lookup("kubeconfig"))   //nolint:errcheck,gosec
-	viper.BindPFlag("namespace", cmd.Flags().Lookup("namespace"))     //nolint:errcheck,gosec
+	viper.BindPFlag("namespaces", cmd.Flags().Lookup("namespaces"))   //nolint:errcheck,gosec
 	viper.BindPFlag("upgrade-olm", cmd.Flags().Lookup("upgrade-olm")) //nolint:errcheck,gosec
 	viper.BindPFlag("skip-wizard", cmd.Flags().Lookup("skip-wizard")) //nolint:errcheck,gosec
 }

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/go-version v1.6.0
 	github.com/operator-framework/api v0.22.0
 	github.com/operator-framework/operator-lifecycle-manager v0.26.0
-	github.com/percona/everest-operator v0.6.0-dev1.0.20240207193854-cdd70b8eb1e6
+	github.com/percona/everest-operator v0.6.0-dev1.0.20240214112044-8f2dea595284
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.8.4

--- a/go.sum
+++ b/go.sum
@@ -525,8 +525,8 @@ github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/9
 github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAvS1LBMMhTE=
 github.com/pelletier/go-toml/v2 v2.1.0 h1:FnwAJ4oYMvbT/34k9zzHuZNrhlz48GB3/s6at6/MHO4=
 github.com/pelletier/go-toml/v2 v2.1.0/go.mod h1:tJU2Z3ZkXwnxa4DPO899bsyIoywizdUvyaeZurnPPDc=
-github.com/percona/everest-operator v0.6.0-dev1.0.20240207193854-cdd70b8eb1e6 h1:leGa/XuWVstdYyj61r92xByjuT52jsbVroHB0fj4j7A=
-github.com/percona/everest-operator v0.6.0-dev1.0.20240207193854-cdd70b8eb1e6/go.mod h1:45pGpvWrPy495qiQqxNuOJor4wif+vTTTJP4Qee8qZk=
+github.com/percona/everest-operator v0.6.0-dev1.0.20240214112044-8f2dea595284 h1:5LKWEvGtaimDPVI3Rj9tFxO+g/zAjUJq0yFIzznQGfc=
+github.com/percona/everest-operator v0.6.0-dev1.0.20240214112044-8f2dea595284/go.mod h1:45pGpvWrPy495qiQqxNuOJor4wif+vTTTJP4Qee8qZk=
 github.com/percona/percona-backup-mongodb v1.8.1-0.20230920143330-3b1c2e263901 h1:BDgsZRCjEuxl2/z4yWBqB0s8d20shuIDks7/RVdZiLs=
 github.com/percona/percona-backup-mongodb v1.8.1-0.20230920143330-3b1c2e263901/go.mod h1:fZRCMpUqkWlLVdRKqqaj001LoVP2eo6F0ZhoMPeXDng=
 github.com/percona/percona-postgresql-operator v0.0.0-20231220140959-ad5eef722609 h1:+UOK4gcHrRgqjo4smgfwT7/0apF6PhAJdQIdAV4ub/M=

--- a/install.sh
+++ b/install.sh
@@ -35,7 +35,7 @@ fi
 echo "Provisioning Everest with monitoring disabled"
 echo "If you want to enable monitoring please refer to the everest installation documentation."
 echo ""
-./everestctl install --namespace everest --operator.mongodb=true --operator.postgresql=true --operator.xtradb-cluster=true --skip-wizard
+./everestctl install --namespaces everest --operator.mongodb=true --operator.postgresql=true --operator.xtradb-cluster=true --skip-wizard
 
 echo "Your provisioned Everest instance will be available at http://127.0.0.1:8080"
 echo "Exposing Everest using kubectl port-forwarding. You can expose it manually"

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -91,7 +91,7 @@ type (
 	// Config stores configuration for the operators.
 	Config struct {
 		// Namespaces defines namespaces that everest can operate in.
-		Namespaces []string `mapstructure:"namespace"`
+		Namespaces string `mapstructure:"namespaces"`
 		// SkipWizard skips wizard during installation.
 		SkipWizard bool `mapstructure:"skip-wizard"`
 		// KubeconfigPath is a path to a kubeconfig
@@ -110,6 +110,10 @@ type (
 		PXC bool `mapstructure:"xtradb-cluster"`
 	}
 )
+
+func (c Config) NamespacesList() []string {
+	return strings.Split(c.Namespaces, ",")
+}
 
 // NewInstall returns a new Install struct.
 func NewInstall(c Config, l *zap.SugaredLogger) (*Install, error) {
@@ -179,9 +183,10 @@ func (o *Install) populateConfig() error {
 	}
 
 	if len(o.config.Namespaces) == 0 {
-		return errors.New("namespace list is empty. Specify at least one namespace using the --namespace flag")
+		return errors.New("namespace list is empty. Specify the comma-separated list of namespaces using the --namespaces flag, at least one namespace is required")
 	}
-	for _, ns := range o.config.Namespaces {
+
+	for _, ns := range o.config.NamespacesList() {
 		if ns == SystemNamespace || ns == monitoringNamespace {
 			return fmt.Errorf("'%s' namespace is reserved for Everest internals. Please specify another namespace", ns)
 		}
@@ -239,7 +244,7 @@ func (o *Install) provisionEverestOperator(ctx context.Context) error {
 	}
 
 	o.l.Info("Creating operator group for everest")
-	if err := o.kubeClient.CreateOperatorGroup(ctx, systemOperatorGroup, SystemNamespace, o.config.Namespaces); err != nil {
+	if err := o.kubeClient.CreateOperatorGroup(ctx, systemOperatorGroup, SystemNamespace, o.config.NamespacesList()); err != nil {
 		return err
 	}
 
@@ -277,7 +282,7 @@ func (o *Install) provisionEverest(ctx context.Context) error {
 	}
 
 	o.l.Info("Updating cluster role bindings for everest-admin")
-	if err := o.kubeClient.UpdateClusterRoleBinding(ctx, everestServiceAccountClusterRoleBinding, o.config.Namespaces); err != nil {
+	if err := o.kubeClient.UpdateClusterRoleBinding(ctx, everestServiceAccountClusterRoleBinding, o.config.NamespacesList()); err != nil {
 		return err
 	}
 
@@ -285,7 +290,7 @@ func (o *Install) provisionEverest(ctx context.Context) error {
 }
 
 func (o *Install) provisionDBNamespaces(ctx context.Context) error {
-	for _, namespace := range o.config.Namespaces {
+	for _, namespace := range o.config.NamespacesList() {
 		namespace := namespace
 		if err := o.createNamespace(namespace); err != nil {
 			return err
@@ -349,7 +354,7 @@ func (o *Install) runEverestWizard() error {
 			return fmt.Errorf("'%s' namespace is reserved for Everest internals. Please specify another namespace", ns)
 		}
 
-		o.config.Namespaces = append(o.config.Namespaces, ns)
+		o.config.Namespaces += "," + ns
 	}
 
 	if len(o.config.Namespaces) == 0 {
@@ -497,7 +502,7 @@ func (o *Install) installOperator(ctx context.Context, channel, operatorName, na
 			},
 		}
 		if operatorName == everestOperatorName {
-			params.TargetNamespaces = o.config.Namespaces
+			params.TargetNamespaces = o.config.NamespacesList()
 			params.SubscriptionConfig.Env = append(params.SubscriptionConfig.Env, []corev1.EnvVar{
 				{
 					Name:  EverestMonitoringNamespaceEnvVar,
@@ -505,7 +510,7 @@ func (o *Install) installOperator(ctx context.Context, channel, operatorName, na
 				},
 				{
 					Name:  kubernetes.EverestDBNamespacesEnvVar,
-					Value: strings.Join(o.config.Namespaces, ","),
+					Value: o.config.Namespaces,
 				},
 			}...)
 		}

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -355,7 +355,11 @@ func (o *Install) runEverestWizard() error {
 			return fmt.Errorf("'%s' namespace is reserved for Everest internals. Please specify another namespace", ns)
 		}
 
-		o.config.Namespaces += "," + ns
+		if o.config.Namespaces != "" {
+			o.config.Namespaces += ","
+		}
+
+		o.config.Namespaces += ns
 	}
 
 	if len(o.config.NamespacesList()) == 0 {

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -183,7 +183,7 @@ func (o *Install) populateConfig() error {
 		}
 	}
 
-	if len(o.config.Namespaces) == 0 {
+	if len(o.config.NamespacesList()) == 0 {
 		return errors.New("namespace list is empty. Specify the comma-separated list of namespaces using the --namespaces flag, at least one namespace is required")
 	}
 
@@ -358,7 +358,7 @@ func (o *Install) runEverestWizard() error {
 		o.config.Namespaces += "," + ns
 	}
 
-	if len(o.config.Namespaces) == 0 {
+	if len(o.config.NamespacesList()) == 0 {
 		return errors.New("namespace list is empty. Specify at least one namespace")
 	}
 

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -90,7 +90,7 @@ const (
 type (
 	// Config stores configuration for the operators.
 	Config struct {
-		// Namespaces defines namespaces that everest can operate in.
+		// Namespaces defines comma-separated list of namespaces that everest can operate in.
 		Namespaces string `mapstructure:"namespaces"`
 		// SkipWizard skips wizard during installation.
 		SkipWizard bool `mapstructure:"skip-wizard"`
@@ -111,6 +111,7 @@ type (
 	}
 )
 
+// NamespacesList returns list of the namespaces that everest can operate in.
 func (c Config) NamespacesList() []string {
 	return strings.Split(c.Namespaces, ",")
 }

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -631,7 +631,7 @@ type InstallOperatorRequest struct {
 func mergeNamespacesEnvVar(str1, str2 string) string {
 	ns1 := strings.Split(str1, ",")
 	ns2 := strings.Split(str2, ",")
-	nsMap := map[string]struct{}{}
+	nsMap := make(map[string]struct{})
 
 	for _, ns := range ns1 {
 		if ns == "" {

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -37,7 +37,7 @@ import (
 type (
 	// Config defines configuration required for upgrade command.
 	Config struct {
-		// Namespaces defines namespaces that everest can operate in.
+		// Namespaces defines comma-separated list of namespaces that everest can operate in.
 		Namespaces string `mapstructure:"namespaces"`
 		// KubeconfigPath is a path to a kubeconfig
 		KubeconfigPath string `mapstructure:"kubeconfig"`
@@ -55,6 +55,7 @@ type (
 	}
 )
 
+// NamespacesList returns list of the namespaces that everest can operate in.
 func (c Config) NamespacesList() []string {
 	return strings.Split(c.Namespaces, ",")
 }

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
 	goversion "github.com/hashicorp/go-version"
@@ -37,7 +38,7 @@ type (
 	// Config defines configuration required for upgrade command.
 	Config struct {
 		// Namespaces defines namespaces that everest can operate in.
-		Namespaces []string `mapstructure:"namespace"`
+		Namespaces string `mapstructure:"namespaces"`
 		// KubeconfigPath is a path to a kubeconfig
 		KubeconfigPath string `mapstructure:"kubeconfig"`
 		// UpgradeOLM defines do we need to upgrade OLM or not.
@@ -53,6 +54,10 @@ type (
 		kubeClient *kubernetes.Kubernetes
 	}
 )
+
+func (c Config) NamespacesList() []string {
+	return strings.Split(c.Namespaces, ",")
+}
 
 // NewUpgrade returns a new Upgrade struct.
 func NewUpgrade(c Config, l *zap.SugaredLogger) (*Upgrade, error) {
@@ -126,7 +131,7 @@ func (u *Upgrade) runEverestWizard(ctx context.Context) error {
 }
 
 func (u *Upgrade) patchSubscriptions(ctx context.Context) error {
-	for _, namespace := range u.config.Namespaces {
+	for _, namespace := range u.config.NamespacesList() {
 		namespace := namespace
 		subList, err := u.kubeClient.ListSubscriptions(ctx, namespace)
 		if err != nil {

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -85,7 +85,7 @@ func (u *Upgrade) Run(ctx context.Context) error {
 	if err := u.runEverestWizard(ctx); err != nil {
 		return err
 	}
-	if len(u.config.Namespaces) == 0 {
+	if len(u.config.NamespacesList()) == 0 {
 		return errors.New("namespace list is empty. Specify at least one namespace")
 	}
 	if err := u.upgradeOLM(ctx); err != nil {


### PR DESCRIPTION
**Change the namespace flag**
---
**Problem:**
EVEREST-843

Change `namespace` flag to `namespaces` which accepts the comma-separated list of namespaces

**Cause:**
Consistency reasons: the wizard accepts a comma-separated list.


**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
