### PR TITLE
EVEREST-855 Fix namespaces validation

### DIFF
--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -111,6 +111,9 @@ type (
 
 // NamespacesList returns list of the namespaces that everest can operate in.
 func (c Config) NamespacesList() []string {
+	if len(c.Namespaces) == 0 {
+		return []string{}
+	}
 	return strings.Split(c.Namespaces, ",")
 }
 


### PR DESCRIPTION
**Fix namespaces validation**
---
**Problem:**
EVEREST-855

Wizard allowed an empty namespace

**Cause:**
Missed cornercase:`strings.Split` applied to an empty string returns a slice of length 1 (with an empty string as the first element), which from the implementation perspective was considered as a defined namespace. 

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
